### PR TITLE
chore: disable docker image build

### DIFF
--- a/.github/workflows/build-ci-image.yml
+++ b/.github/workflows/build-ci-image.yml
@@ -1,8 +1,6 @@
 name: Build and Push Docker Image
 
 on:
-  push:
-    branches: [ main ]
   workflow_dispatch:  # Allow manual triggering
 
 jobs:


### PR DESCRIPTION
# Summary
It's too slow to build, better solution will be to cache things smarter