### PR TITLE
feat: implement variadics in bindings via `VariadicTuple` and add `ScriptValue::Tuple`

### DIFF
--- a/assets/tests/variadics/variadics.lua
+++ b/assets/tests/variadics/variadics.lua
@@ -1,0 +1,10 @@
+function on_test()
+    local unpacked_a, unpacked_b = unpack_args({ 1, 2 })
+
+    local packed = pack_args(1, 2)
+
+    assert(packed[1] == unpacked_a,
+        "Expected packed[1] to be: " .. tostring(unpacked_a) .. " Got: " .. tostring(packed[1]))
+    assert(packed[2] == unpacked_b,
+        "Expected packed[2] to be:" .. tostring(unpacked_b) .. " Got: " .. tostring(packed[2]))
+end

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -2,7 +2,7 @@ extern crate bevy_mod_scripting;
 extern crate script_integration_test_harness;
 extern crate test_utils;
 use bevy_platform::collections::HashMap;
-use std::{path::PathBuf, sync::LazyLock, time::Duration};
+use std::{collections::VecDeque, path::PathBuf, sync::LazyLock, time::Duration};
 
 use bevy::{
     log::{
@@ -173,9 +173,9 @@ fn conversion_benchmarks(criterion: &mut Criterion) {
     perform_benchmark_with_generator(
         "ScriptValue::List",
         &|rng, _| {
-            let mut array = Vec::new();
+            let mut array = VecDeque::new();
             for _ in 0..10 {
-                array.push(ScriptValue::Integer(rng.random()));
+                array.push_back(ScriptValue::Integer(rng.random()));
             }
             ScriptValue::List(array)
         },

--- a/crates/bevy_mod_scripting_bindings/src/docgen/info.rs
+++ b/crates/bevy_mod_scripting_bindings/src/docgen/info.rs
@@ -10,6 +10,10 @@ use std::{any::TypeId, borrow::Cow};
 use super::typed_through::{ThroughTypeInfo, TypedThrough};
 
 /// for things you can call and provide some introspection capability.
+#[diagnostic::on_unimplemented(
+    message = "This function contains types in its signature which don't implement [`ArgMeta`] or [`TypedThrough`].",
+    note = "These types are necessary to build [`FunctionInfo`] structs for each registered function."
+)]
 pub trait GetFunctionInfo<Marker> {
     /// Get the function info for the function.
     fn get_function_info(&self, name: Cow<'static, str>, namespace: Namespace) -> FunctionInfo;

--- a/crates/bevy_mod_scripting_bindings/src/docgen/typed_through.rs
+++ b/crates/bevy_mod_scripting_bindings/src/docgen/typed_through.rs
@@ -1,10 +1,10 @@
 //! Defines a set of traits which destruture [`bevy_reflect::TypeInfo`] and implement a light weight wrapper around it, to allow types
 //! which normally can't implement [`bevy_reflect::Typed`] to be used in a reflection context.
 
-use std::{any::TypeId, ffi::OsString, path::PathBuf};
+use std::{any::TypeId, collections::VecDeque, ffi::OsString, path::PathBuf};
 
 use crate::{
-    ReflectReference,
+    ReflectReference, VariadicTuple,
     function::{
         from::{M, R, Union, V},
         script_function::{DynamicScriptFunction, DynamicScriptFunctionMut, FunctionCallContext},
@@ -76,6 +76,8 @@ pub enum TypedWrapperKind {
     InteropResult(Box<ThroughTypeInfo>),
     /// Wraps a tuple of through typed types.
     Tuple(Vec<ThroughTypeInfo>),
+    /// Wraps a tuple of script values
+    UntypedTuple,
 }
 
 /// A dynamic version of [`TypedThrough`], which can be used to convert a [`TypeInfo`] into a [`ThroughTypeInfo`].
@@ -248,6 +250,12 @@ impl<T: TypedThrough> TypedThrough for Vec<T> {
     }
 }
 
+impl<T: TypedThrough> TypedThrough for VecDeque<T> {
+    fn through_type_info() -> ThroughTypeInfo {
+        ThroughTypeInfo::TypedWrapper(TypedWrapperKind::Vec(Box::new(T::through_type_info())))
+    }
+}
+
 impl<K: TypedThrough, V: TypedThrough> TypedThrough for HashMap<K, V> {
     fn through_type_info() -> ThroughTypeInfo {
         ThroughTypeInfo::TypedWrapper(TypedWrapperKind::HashMap(
@@ -283,6 +291,12 @@ impl<T: TypedThrough, const N: usize> TypedThrough for [T; N] {
 impl<T: TypedThrough> TypedThrough for Option<T> {
     fn through_type_info() -> ThroughTypeInfo {
         ThroughTypeInfo::TypedWrapper(TypedWrapperKind::Option(Box::new(T::through_type_info())))
+    }
+}
+
+impl TypedThrough for VariadicTuple {
+    fn through_type_info() -> ThroughTypeInfo {
+        ThroughTypeInfo::TypedWrapper(TypedWrapperKind::UntypedTuple)
     }
 }
 

--- a/crates/bevy_mod_scripting_bindings/src/function/arg_meta.rs
+++ b/crates/bevy_mod_scripting_bindings/src/function/arg_meta.rs
@@ -1,10 +1,12 @@
 //! Trait implementations to help with function dispatch.
 
-use std::{ffi::OsString, path::PathBuf};
+use std::{collections::VecDeque, ffi::OsString, path::PathBuf};
 
 use bevy_platform::collections::HashMap;
 
-use crate::{ReflectReference, ScriptValue, docgen::TypedThrough, error::InteropError};
+use crate::{
+    ReflectReference, ScriptValue, VariadicTuple, docgen::TypedThrough, error::InteropError,
+};
 
 use super::{
     from::{FromScript, M, R, Union, V},
@@ -35,9 +37,24 @@ pub trait ArgMeta {
     fn default_value() -> Option<ScriptValue> {
         None
     }
+
+    /// If returns true, will absorb all arguments following itself
+    fn variadic() -> bool {
+        false
+    }
 }
 
 impl ArgMeta for ScriptValue {}
+
+impl ArgMeta for VariadicTuple {
+    fn default_value() -> Option<ScriptValue> {
+        Some(ScriptValue::Tuple(Default::default()))
+    }
+
+    fn variadic() -> bool {
+        true
+    }
+}
 
 macro_rules! impl_arg_info {
     ($($ty:ty),*) => {
@@ -85,6 +102,8 @@ impl<T> ArgMeta for Option<T> {
 }
 
 impl<T> ArgMeta for Vec<T> {}
+impl<T> ArgMeta for VecDeque<T> {}
+
 impl<T, const N: usize> ArgMeta for [T; N] {}
 
 impl<K, V> ArgMeta for HashMap<K, V> {}

--- a/crates/bevy_mod_scripting_bindings/src/function/from.rs
+++ b/crates/bevy_mod_scripting_bindings/src/function/from.rs
@@ -2,12 +2,14 @@
 
 use crate::{
     ReflectReference, ScriptValue, WorldGuard, access_map::ReflectAccessId, error::InteropError,
+    script_value::VariadicTuple,
 };
 use bevy_platform::collections::{HashMap, HashSet};
 use bevy_reflect::{FromReflect, Reflect};
 use nonmax::NonMaxU32;
 use std::{
     any::TypeId,
+    collections::VecDeque,
     ffi::OsString,
     ops::{Deref, DerefMut},
     path::PathBuf,
@@ -412,6 +414,30 @@ where
 }
 
 #[profiling::all_functions]
+impl<T: FromScript + 'static> FromScript for VecDeque<T>
+where
+    for<'w> T::This<'w>: Into<T>,
+{
+    type This<'w> = Self;
+    #[profiling::function]
+    fn from_script(value: ScriptValue, world: WorldGuard) -> Result<Self, InteropError> {
+        match value {
+            ScriptValue::List(list) => {
+                let mut vec = VecDeque::with_capacity(list.len());
+                for item in list {
+                    vec.push_back(T::from_script(item, world.clone())?.into());
+                }
+                Ok(vec)
+            }
+            _ => Err(InteropError::value_mismatch(
+                std::any::TypeId::of::<VecDeque<T>>(),
+                value,
+            )),
+        }
+    }
+}
+
+#[profiling::all_functions]
 impl<T: FromScript + 'static, const N: usize> FromScript for [T; N]
 where
     for<'w> T::This<'w>: Into<T>,
@@ -615,6 +641,23 @@ where
     }
 }
 
+impl FromScript for VariadicTuple {
+    type This<'w> = Self;
+
+    fn from_script(
+        value: ScriptValue,
+        _world: WorldGuard<'_>,
+    ) -> Result<Self::This<'_>, InteropError>
+    where
+        Self: Sized,
+    {
+        match value {
+            ScriptValue::List(tuple) | ScriptValue::Tuple(VariadicTuple(tuple)) => Ok(Self(tuple)),
+            v => Ok(Self(VecDeque::from_iter([v]))),
+        }
+    }
+}
+
 macro_rules! impl_from_script_tuple {
     ($($ty:ident),*) => {
         #[allow(non_snake_case)]
@@ -630,7 +673,7 @@ macro_rules! impl_from_script_tuple {
 
             fn from_script(value: ScriptValue, world: WorldGuard<'_>) -> Result<Self, InteropError> {
                 match value {
-                    ScriptValue::List(list) => {
+                    ScriptValue::List(list) | ScriptValue::Tuple(VariadicTuple(list)) => {
                         let expected_arg_count = $crate::function::script_function::count!( $($ty)* );
                         if list.len() != expected_arg_count {
                             return Err(InteropError::length_mismatch(expected_arg_count, list.len()));

--- a/crates/bevy_mod_scripting_bindings/src/function/into.rs
+++ b/crates/bevy_mod_scripting_bindings/src/function/into.rs
@@ -1,10 +1,10 @@
 //! Implementations of the [`IntoScript`] trait for various types.
 
 use super::{DynamicScriptFunction, DynamicScriptFunctionMut, Union, V};
-use crate::{ReflectReference, ScriptValue, WorldGuard, error::InteropError};
+use crate::{ReflectReference, ScriptValue, VariadicTuple, WorldGuard, error::InteropError};
 use bevy_platform::collections::HashMap;
 use bevy_reflect::Reflect;
-use std::{borrow::Cow, ffi::OsString, path::PathBuf};
+use std::{borrow::Cow, collections::VecDeque, ffi::OsString, path::PathBuf};
 
 /// Converts a value into a [`ScriptValue`].
 pub trait IntoScript {
@@ -136,9 +136,20 @@ impl<T: IntoScript> IntoScript for Option<T> {
 #[profiling::all_functions]
 impl<T: IntoScript> IntoScript for Vec<T> {
     fn into_script(self, world: WorldGuard) -> Result<ScriptValue, InteropError> {
-        let mut values = Vec::with_capacity(self.len());
+        let mut values = VecDeque::with_capacity(self.len());
         for val in self {
-            values.push(val.into_script(world.clone())?);
+            values.push_back(val.into_script(world.clone())?);
+        }
+        Ok(ScriptValue::List(values))
+    }
+}
+
+#[profiling::all_functions]
+impl<T: IntoScript> IntoScript for VecDeque<T> {
+    fn into_script(self, world: WorldGuard) -> Result<ScriptValue, InteropError> {
+        let mut values = VecDeque::with_capacity(self.len());
+        for val in self {
+            values.push_back(val.into_script(world.clone())?);
         }
         Ok(ScriptValue::List(values))
     }
@@ -147,9 +158,9 @@ impl<T: IntoScript> IntoScript for Vec<T> {
 #[profiling::all_functions]
 impl<T: IntoScript, const N: usize> IntoScript for [T; N] {
     fn into_script(self, world: WorldGuard) -> Result<ScriptValue, InteropError> {
-        let mut values = Vec::with_capacity(N);
+        let mut values = VecDeque::with_capacity(N);
         for val in self {
-            values.push(val.into_script(world.clone())?);
+            values.push_back(val.into_script(world.clone())?);
         }
         Ok(ScriptValue::List(values))
     }
@@ -194,6 +205,12 @@ impl IntoScript for InteropError {
     }
 }
 
+impl IntoScript for VariadicTuple {
+    fn into_script(self, _world: WorldGuard) -> Result<ScriptValue, InteropError> {
+        Ok(ScriptValue::Tuple(self))
+    }
+}
+
 macro_rules! impl_into_script_tuple {
     ($( $ty:ident ),* ) => {
         #[allow(non_snake_case)]
@@ -201,7 +218,7 @@ macro_rules! impl_into_script_tuple {
         impl<$($ty: IntoScript),*> IntoScript for ($($ty,)*) {
         fn into_script(self, world: WorldGuard) -> Result<ScriptValue, InteropError> {
             let ($($ty,)*) = self;
-            Ok(ScriptValue::List(vec![$($ty.into_script(world.clone())?),*]))
+            Ok(ScriptValue::Tuple(crate::script_value::VariadicTuple(VecDeque::from_iter([$($ty.into_script(world.clone())?),*].into_iter()))))
         }
     }
 }

--- a/crates/bevy_mod_scripting_bindings/src/function/script_function.rs
+++ b/crates/bevy_mod_scripting_bindings/src/function/script_function.rs
@@ -2,6 +2,7 @@
 
 use super::MagicFunctions;
 use super::{from::FromScript, into::IntoScript, namespace::Namespace};
+use crate::VariadicTuple;
 use crate::docgen::info::{FunctionInfo, GetFunctionInfo};
 use crate::function::arg_meta::ArgMeta;
 use crate::{ScriptValue, ThreadWorldContainer, WorldGuard, error::InteropError};
@@ -17,10 +18,8 @@ use std::collections::VecDeque;
 use std::hash::Hash;
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
-
 #[diagnostic::on_unimplemented(
-    message = "This function does not fulfil the requirements to be a script callable function. All arguments must implement the ScriptArgument trait and all return values must implement the ScriptReturn trait",
-    note = "If you're trying to return a non-primitive type, you might need to use V<T> R<T> or M<T> wrappers"
+    message = "This function does not fulfil the requirements to be a script callable function. All arguments must implement the ScriptArgument trait and all return values must implement the ScriptReturn trait"
 )]
 /// A trait implemented by functions which can act as dynamic script functions, which can then be registered against a [`ScriptFunctionRegistry`].
 pub trait ScriptFunction<'env, Marker> {
@@ -30,7 +29,7 @@ pub trait ScriptFunction<'env, Marker> {
 
 #[diagnostic::on_unimplemented(
     message = "Only functions with all arguments impplementing FromScript and return values supporting IntoScript are supported. Registering functions also requires they implement GetTypeDependencies",
-    note = "If you're trying to return a non-primitive type, you might need to use V<T> R<T> or M<T> wrappers"
+    note = "If you're trying to use a non-primitive type, you might need to use V<T> R<T> or M<T> wrappers"
 )]
 /// A trait implemented by functions which can act as mutable dynamic script functions.
 pub trait ScriptFunctionMut<'env, Marker> {
@@ -608,6 +607,22 @@ macro_rules! count {
         ( $x:tt $($xs:tt)* ) => (1usize + $crate::function::script_function::count!($($xs)*));
 }
 
+/// Pops the stack of args depending on how many are requested by the current argument.
+/// If failed to find argument, returns None
+fn pop_args_stack_for_arg<A: ArgMeta>(args: &mut VecDeque<ScriptValue>) -> Option<ScriptValue> {
+    if A::variadic() {
+        // just absorb the rest, tuplify it
+        if !args.is_empty() {
+            return Some(ScriptValue::Tuple(VariadicTuple(std::mem::take(args))));
+        }
+    }
+    if let Some(default) = A::default_value() {
+        return Some(default);
+    }
+
+    args.pop_front()
+}
+
 pub(crate) use count;
 
 macro_rules! impl_script_function {
@@ -674,15 +689,10 @@ macro_rules! impl_script_function {
                                 $(let $param = {
                                         profiling::scope!("argument conversion", &format!("argument #{}", current_arg));
                                         current_arg += 1;
-                                        let $param = args.pop_front();
-                                        let $param = match $param {
+                                        let $param = match pop_args_stack_for_arg::<$param>(&mut args) {
                                             Some($param) => $param,
                                             None => {
-                                                if let Some(default) = <$param>::default_value() {
-                                                    default
-                                                } else {
-                                                    return Err(InteropError::argument_count_mismatch(expected_arg_count,received_args_len));
-                                                }
+                                                return Err(InteropError::argument_count_mismatch(expected_arg_count,received_args_len));
                                             }
                                         };
                                         let $param = <$param>::from_script($param, world.clone())

--- a/crates/bevy_mod_scripting_bindings/src/function/script_function.rs
+++ b/crates/bevy_mod_scripting_bindings/src/function/script_function.rs
@@ -616,11 +616,8 @@ fn pop_args_stack_for_arg<A: ArgMeta>(args: &mut VecDeque<ScriptValue>) -> Optio
             return Some(ScriptValue::Tuple(VariadicTuple(std::mem::take(args))));
         }
     }
-    if let Some(default) = A::default_value() {
-        return Some(default);
-    }
 
-    args.pop_front()
+    args.pop_front().or_else(A::default_value)
 }
 
 pub(crate) use count;

--- a/crates/bevy_mod_scripting_bindings/src/function/type_dependencies.rs
+++ b/crates/bevy_mod_scripting_bindings/src/function/type_dependencies.rs
@@ -5,11 +5,11 @@ use super::{
     from::{M, R, Union, V},
     script_function::FunctionCallContext,
 };
-use crate::{ReflectReference, ScriptValue, error::InteropError};
+use crate::{ReflectReference, ScriptValue, VariadicTuple, error::InteropError};
 use bevy_mod_scripting_derive::impl_get_type_dependencies;
 use bevy_platform::collections::HashMap;
 use bevy_reflect::{FromReflect, GetTypeRegistration, TypeRegistry, Typed};
-use std::collections::HashMap as StdHashMap;
+use std::collections::{HashMap as StdHashMap, VecDeque};
 use std::{ffi::OsString, hash::Hash, path::PathBuf};
 
 macro_rules! impl_get_type_dependencies_primitives {
@@ -119,6 +119,14 @@ impl_get_type_dependencies!(
 
 impl_get_type_dependencies!(
     #[derive(GetTypeDependencies)]
+    #[get_type_dependencies(bms_bindings_path = "crate")]
+    struct VecDeque<T>
+    where
+        T::Underlying: FromReflect + Typed, {}
+);
+
+impl_get_type_dependencies!(
+    #[derive(GetTypeDependencies)]
     #[get_type_dependencies(
         bms_bindings_path = "crate",
         underlying = "Result<T1::Underlying,T2::Underlying>"
@@ -159,6 +167,12 @@ impl_get_type_dependencies!(
     struct FunctionCallContext {}
 );
 
+impl_get_type_dependencies!(
+    #[derive(GetTypeDependencies)]
+    #[get_type_dependencies(bms_bindings_path = "crate")]
+    struct VariadicTuple {}
+);
+
 impl<T, const N: usize> GetTypeDependencies for [T; N]
 where
     T: GetTypeDependencies,
@@ -191,6 +205,10 @@ macro_rules! register_tuple_dependencies {
 
 variadics_please::all_tuples!(register_tuple_dependencies, 1, 14, T);
 
+#[diagnostic::on_unimplemented(
+    message = "This function contains types in its signature which don't implement [`Reflect`].",
+    note = "Reflection is necessary to register nested type dependencies with the type registry"
+)]
 /// A trait collecting type dependency information for a whole function. Used to register everything used by a function with the type registry
 pub trait GetFunctionTypeDependencies<Marker> {
     /// Registers the type dependencies of the implementing type with the given [`TypeRegistry`].

--- a/crates/bevy_mod_scripting_bindings/src/script_value.rs
+++ b/crates/bevy_mod_scripting_bindings/src/script_value.rs
@@ -7,7 +7,7 @@ use bevy_mod_scripting_display::{
 };
 use bevy_platform::collections::HashMap;
 use bevy_reflect::Reflect;
-use std::borrow::Cow;
+use std::{borrow::Cow, collections::VecDeque};
 
 use super::{
     ReflectReference,
@@ -32,7 +32,10 @@ pub enum ScriptValue {
     /// Represents a string value.
     String(Cow<'static, str>),
     /// Represents a list of other things passed by value
-    List(Vec<ScriptValue>),
+    List(VecDeque<ScriptValue>),
+    /// Represents a tuple of values, which is best intepreted as multiple non-homogenous values.
+    /// If returned by a function, scripting languages supporting multiple return values can use this type to represent those.
+    Tuple(VariadicTuple),
     /// Represents a map of other things passed by value
     Map(HashMap<String, ScriptValue>),
     /// Represents a reference to a value.
@@ -44,6 +47,12 @@ pub enum ScriptValue {
     /// Represents any error, will be thrown when returned to a script.
     Error(InteropError),
 }
+
+/// A tuple variant of script value
+#[derive(Reflect, Clone, Default, DebugWithTypeInfo)]
+#[reflect(opaque)]
+#[debug_with_type_info(bms_display_path = "bevy_mod_scripting_display")]
+pub struct VariadicTuple(pub VecDeque<ScriptValue>);
 
 impl DisplayWithTypeInfo for ScriptValue {
     fn display_with_type_info(
@@ -57,6 +66,19 @@ impl DisplayWithTypeInfo for ScriptValue {
             ScriptValue::Integer(v) => write!(f, "{v}"),
             ScriptValue::Float(v) => write!(f, "{v}"),
             ScriptValue::String(v) => write!(f, "{v}"),
+            ScriptValue::Tuple(VariadicTuple(v)) => {
+                f.write_str("(")?;
+                let mut first = true;
+                for item in v {
+                    if !first {
+                        f.write_str(", ")?;
+                    }
+                    first = false;
+                    WithTypeInfo::new_with_opt_info(item, type_info_provider)
+                        .display_with_type_info(f, type_info_provider)?;
+                }
+                f.write_str(")")
+            }
             ScriptValue::List(v) => {
                 f.write_str("[")?;
                 let mut first = true;
@@ -128,6 +150,7 @@ impl ScriptValue {
             ScriptValue::Float(_) => "Float".to_owned(),
             ScriptValue::String(_) => "String".to_owned(),
             ScriptValue::List(_) => "List".to_owned(),
+            ScriptValue::Tuple(_) => "Tuple".to_owned(),
             ScriptValue::Reference(_) => "Reference".to_owned(),
             ScriptValue::FunctionMut(_) => "FunctionMut".to_owned(),
             ScriptValue::Function(_) => "Function".to_owned(),
@@ -187,8 +210,8 @@ impl From<Cow<'static, str>> for ScriptValue {
 }
 
 #[profiling::all_functions]
-impl From<Vec<ScriptValue>> for ScriptValue {
-    fn from(value: Vec<ScriptValue>) -> Self {
+impl From<VecDeque<ScriptValue>> for ScriptValue {
+    fn from(value: VecDeque<ScriptValue>) -> Self {
         ScriptValue::List(value)
     }
 }

--- a/crates/bevy_mod_scripting_display/src/impls/std.rs
+++ b/crates/bevy_mod_scripting_display/src/impls/std.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, panic::Location, sync::Arc};
+use std::{borrow::Cow, collections::VecDeque, panic::Location, sync::Arc};
 
 use crate::*;
 
@@ -93,6 +93,18 @@ impl<T: DebugWithTypeInfo, E: DebugWithTypeInfo> DebugWithTypeInfo for Result<T,
 }
 
 impl<T: DebugWithTypeInfo> DebugWithTypeInfo for Vec<T> {
+    fn to_string_with_type_info(
+        &self,
+        f: &mut std::fmt::Formatter<'_>,
+        type_info_provider: Option<&dyn GetTypeInfo>,
+    ) -> std::fmt::Result {
+        f.debug_list_with_type_info(type_info_provider)
+            .entries(self.iter().map(|v| v as &dyn DebugWithTypeInfo))
+            .finish()
+    }
+}
+
+impl<T: DebugWithTypeInfo> DebugWithTypeInfo for VecDeque<T> {
     fn to_string_with_type_info(
         &self,
         f: &mut std::fmt::Formatter<'_>,
@@ -279,6 +291,25 @@ impl DisplayWithTypeInfo for Location<'_> {
 }
 
 impl<T: DisplayWithTypeInfo> DisplayWithTypeInfo for Vec<T> {
+    fn display_with_type_info(
+        &self,
+        f: &mut std::fmt::Formatter<'_>,
+        type_info_provider: Option<&dyn GetTypeInfo>,
+    ) -> std::fmt::Result {
+        f.write_str("[")?;
+        let mut first = true;
+        for var in self {
+            if !first {
+                f.write_str(", ")?;
+            }
+            first = false;
+            var.display_with_type_info(f, type_info_provider)?;
+        }
+        f.write_str("]")
+    }
+}
+
+impl<T: DisplayWithTypeInfo> DisplayWithTypeInfo for VecDeque<T> {
     fn display_with_type_info(
         &self,
         f: &mut std::fmt::Formatter<'_>,

--- a/crates/bevy_mod_scripting_functions/src/core.rs
+++ b/crates/bevy_mod_scripting_functions/src/core.rs
@@ -3,7 +3,7 @@
 use bevy_mod_scripting_asset::ScriptAsset;
 use bevy_mod_scripting_script::ScriptAttachment;
 use bevy_platform::collections::HashMap;
-use std::ops::Deref;
+use std::{collections::VecDeque, ops::Deref};
 
 use bevy_app::App;
 use bevy_asset::{AssetServer, Handle};
@@ -12,7 +12,7 @@ use bevy_mod_scripting_bindings::{
     DynamicScriptFunction, DynamicScriptFunctionMut, FunctionInfo, GlobalNamespace, InteropError,
     PartialReflectExt, ReflectReference, ScriptComponentRegistration, ScriptQueryBuilder,
     ScriptQueryResult, ScriptResourceRegistration, ScriptTypeRegistration, ThreadWorldContainer,
-    Union,
+    Union, VariadicTuple,
     function::{
         from::{R, V},
         from_ref::FromScriptRef,
@@ -847,7 +847,6 @@ impl ReflectReference {
             let (next_ref, _) = infinite_iter.next_ref();
 
             let converted = ReflectReference::into_script_ref(next_ref, world);
-            // println!("idx: {idx:?}, converted: {converted:?}");
             len -= 1;
             // we stop once the reflection path is invalid
             converted
@@ -1372,37 +1371,6 @@ impl GlobalNamespace {
         // to avoid clippy unused errors.
         println!("dummy called!: {callback:?}, {function:?}");
     }
-
-    /// Logs a `Information` level message to the console
-    /// Arguments:
-    /// * `message`: the message to log
-    fn info(message: String) {
-        bevy_log::info!(message)
-    }
-
-    /// Logs a `Warning` level message to the console
-    /// * `message`: the message to log
-    fn warn(message: String) {
-        bevy_log::warn!(message)
-    }
-
-    /// Logs a `Error` level message to the console
-    /// * `message`: the message to log
-    fn error(message: String) {
-        bevy_log::error!(message)
-    }
-
-    /// Logs a `Debug` level message to the console
-    /// * `message`: the message to log
-    fn debug(message: String) {
-        bevy_log::debug!(message)
-    }
-
-    /// Logs a `Trace` level message to the console
-    /// * `message`: the message to log
-    fn trace(message: String) {
-        bevy_log::trace!(message)
-    }
 }
 
 /// Globals registered by us
@@ -1467,6 +1435,57 @@ impl GlobalNamespace {
         attachment: V<ScriptAttachment>,
     ) -> Result<V<ScriptSystemBuilder>, InteropError> {
         Ok(ScriptSystemBuilder::new(callback.into(), attachment.into_inner()).into())
+    }
+
+    /// Unpacks, a list of values, into many separate values.
+    ///
+    /// Arguments:
+    /// * `values`: The list of values to uncurry
+    /// Returns:
+    /// * `tuple`: The tuple of all values provided
+    fn unpack_args(values: VecDeque<ScriptValue>) -> VariadicTuple {
+        VariadicTuple(values)
+    }
+
+    /// Packs, a variable amount of values, into a single list.
+    ///
+    /// Arguments:
+    /// * `tuple`: The tuple of values to curry
+    /// Returns:
+    /// * `values`: The list of values destructured from the tuple
+    fn pack_args(tuple: VariadicTuple) -> VecDeque<ScriptValue> {
+        tuple.0
+    }
+
+    /// Logs a `Information` level message to the console
+    /// Arguments:
+    /// * `message`: the message to log
+    fn log_info(message: String) {
+        bevy_log::info!(message)
+    }
+
+    /// Logs a `Warning` level message to the console
+    /// * `message`: the message to log
+    fn log_warn(message: String) {
+        bevy_log::warn!(message)
+    }
+
+    /// Logs a `Error` level message to the console
+    /// * `message`: the message to log
+    fn log_error(message: String) {
+        bevy_log::error!(message)
+    }
+
+    /// Logs a `Debug` level message to the console
+    /// * `message`: the message to log
+    fn log_debug(message: String) {
+        bevy_log::debug!(message)
+    }
+
+    /// Logs a `Trace` level message to the console
+    /// * `message`: the message to log
+    fn log_trace(message: String) {
+        bevy_log::trace!(message)
     }
 }
 

--- a/crates/bindings/bevy_a11y_bms_bindings/Cargo.toml
+++ b/crates/bindings/bevy_a11y_bms_bindings/Cargo.toml
@@ -17,7 +17,7 @@ categories.workspace = true
 bevy_mod_scripting_core = { workspace = true }
 bevy_mod_scripting_bindings = { workspace = true }
 bevy_mod_scripting_derive = { workspace = true }
-bevy_a11y = { version = "0.18.0", features = ["bevy_reflect", "std"], default-features = true}
+bevy_a11y = { version = "0.18.1", features = ["bevy_reflect", "std"], default-features = true}
 
 
 bevy_app = { version = "^0.18.0", features = ["bevy_reflect", "error_panic_hook", "reflect_auto_register", "std"], default-features = true}

--- a/crates/bindings/bevy_animation_bms_bindings/Cargo.toml
+++ b/crates/bindings/bevy_animation_bms_bindings/Cargo.toml
@@ -17,7 +17,7 @@ categories.workspace = true
 bevy_mod_scripting_core = { workspace = true }
 bevy_mod_scripting_bindings = { workspace = true }
 bevy_mod_scripting_derive = { workspace = true }
-bevy_animation = { version = "0.18.0", features = ["bevy_mesh"], default-features = true}
+bevy_animation = { version = "0.18.1", features = ["bevy_mesh"], default-features = true}
 
 
 bevy_animation_macros = { version = "^0.18.0", features = [], default-features = true}

--- a/crates/bindings/bevy_asset_bms_bindings/Cargo.toml
+++ b/crates/bindings/bevy_asset_bms_bindings/Cargo.toml
@@ -17,8 +17,10 @@ bevy_app = { workspace = true, features = ["std"] }
 bevy_mod_scripting_core = { workspace = true }
 bevy_mod_scripting_bindings = { workspace = true }
 bevy_mod_scripting_derive = { workspace = true }
-bevy_asset = { version = "0.18.0", features = ["file_watcher", "multi_threaded", "notify-debouncer-full", "watch"], default-features = true}
+bevy_asset = { version = "0.18.1", features = ["file_watcher", "multi_threaded", "notify-debouncer-full", "watch"], default-features = true}
 
+
+async-io = { version = "^2.6", features = [], default-features = true}
 
 bevy_asset_macros = { version = "^0.18.0", features = [], default-features = true}
 

--- a/crates/bindings/bevy_camera_bms_bindings/Cargo.toml
+++ b/crates/bindings/bevy_camera_bms_bindings/Cargo.toml
@@ -17,7 +17,7 @@ categories.workspace = true
 bevy_mod_scripting_core = { workspace = true }
 bevy_mod_scripting_bindings = { workspace = true }
 bevy_mod_scripting_derive = { workspace = true }
-bevy_camera = { version = "0.18.0", features = [], default-features = true}
+bevy_camera = { version = "0.18.1", features = [], default-features = true}
 
 
 bevy_app = { version = "^0.18.0", features = ["bevy_reflect", "error_panic_hook", "reflect_auto_register", "std"], default-features = true}

--- a/crates/bindings/bevy_color_bms_bindings/Cargo.toml
+++ b/crates/bindings/bevy_color_bms_bindings/Cargo.toml
@@ -17,7 +17,7 @@ bevy_app = { workspace = true, features = ["std"] }
 bevy_mod_scripting_core = { workspace = true }
 bevy_mod_scripting_bindings = { workspace = true }
 bevy_mod_scripting_derive = { workspace = true }
-bevy_color = { version = "0.18.0", features = ["alloc", "bevy_reflect", "encase", "std", "wgpu-types"], default-features = true}
+bevy_color = { version = "0.18.1", features = ["alloc", "bevy_reflect", "encase", "std", "wgpu-types"], default-features = true}
 
 
 bevy_math = { version = "^0.18.0", features = ["alloc", "bevy_reflect", "curve", "rand", "std"], default-features = true}

--- a/crates/bindings/bevy_core_pipeline_bms_bindings/Cargo.toml
+++ b/crates/bindings/bevy_core_pipeline_bms_bindings/Cargo.toml
@@ -17,7 +17,7 @@ categories.workspace = true
 bevy_mod_scripting_core = { workspace = true }
 bevy_mod_scripting_bindings = { workspace = true }
 bevy_mod_scripting_derive = { workspace = true }
-bevy_core_pipeline = { version = "0.18.0", features = ["tonemapping_luts", "webgl"], default-features = true}
+bevy_core_pipeline = { version = "0.18.1", features = ["tonemapping_luts", "webgl"], default-features = true}
 
 
 bevy_app = { version = "^0.18.0", features = ["bevy_reflect", "error_panic_hook", "reflect_auto_register", "std"], default-features = true}

--- a/crates/bindings/bevy_ecs_bms_bindings/Cargo.toml
+++ b/crates/bindings/bevy_ecs_bms_bindings/Cargo.toml
@@ -17,7 +17,7 @@ bevy_app = { workspace = true, features = ["std"] }
 bevy_mod_scripting_core = { workspace = true }
 bevy_mod_scripting_bindings = { workspace = true }
 bevy_mod_scripting_derive = { workspace = true }
-bevy_ecs = { version = "0.18.0", features = ["async_executor", "backtrace", "bevy_reflect", "multi_threaded", "reflect_auto_register", "serialize", "std"], default-features = true}
+bevy_ecs = { version = "0.18.1", features = ["async_executor", "backtrace", "bevy_reflect", "multi_threaded", "reflect_auto_register", "serialize", "std"], default-features = true}
 
 
 arrayvec = { version = "^0.7.4", features = ["std"], default-features = false}

--- a/crates/bindings/bevy_gizmos_bms_bindings/Cargo.toml
+++ b/crates/bindings/bevy_gizmos_bms_bindings/Cargo.toml
@@ -17,7 +17,7 @@ categories.workspace = true
 bevy_mod_scripting_core = { workspace = true }
 bevy_mod_scripting_bindings = { workspace = true }
 bevy_mod_scripting_derive = { workspace = true }
-bevy_gizmos = { version = "0.18.0", features = ["bevy_light"], default-features = true}
+bevy_gizmos = { version = "0.18.1", features = ["bevy_light"], default-features = true}
 
 
 bevy_app = { version = "^0.18.0", features = ["bevy_reflect", "error_panic_hook", "reflect_auto_register", "std"], default-features = true}

--- a/crates/bindings/bevy_gltf_bms_bindings/Cargo.toml
+++ b/crates/bindings/bevy_gltf_bms_bindings/Cargo.toml
@@ -17,7 +17,7 @@ categories.workspace = true
 bevy_mod_scripting_core = { workspace = true }
 bevy_mod_scripting_bindings = { workspace = true }
 bevy_mod_scripting_derive = { workspace = true }
-bevy_gltf = { version = "0.18.0", features = ["bevy_animation"], default-features = true}
+bevy_gltf = { version = "0.18.1", features = ["bevy_animation"], default-features = true}
 
 
 base64 = { version = "^0.22.0", features = [], default-features = true}

--- a/crates/bindings/bevy_image_bms_bindings/Cargo.toml
+++ b/crates/bindings/bevy_image_bms_bindings/Cargo.toml
@@ -17,7 +17,7 @@ bevy_ecs = { workspace = true, features = ["std", "bevy_reflect"] }
 bevy_mod_scripting_core = { workspace = true }
 bevy_mod_scripting_bindings = { workspace = true }
 bevy_mod_scripting_derive = { workspace = true }
-bevy_image = { version = "0.18.0", features = ["bevy_reflect", "hdr", "ktx2", "png", "zstd", "zstd_rust"], default-features = true}
+bevy_image = { version = "0.18.1", features = ["bevy_reflect", "hdr", "ktx2", "png", "zstd", "zstd_rust"], default-features = true}
 
 
 bevy_app = { version = "^0.18.0", features = ["bevy_reflect", "error_panic_hook", "reflect_auto_register", "std"], default-features = true}

--- a/crates/bindings/bevy_input_bms_bindings/Cargo.toml
+++ b/crates/bindings/bevy_input_bms_bindings/Cargo.toml
@@ -17,7 +17,7 @@ categories.workspace = true
 bevy_mod_scripting_core = { workspace = true }
 bevy_mod_scripting_bindings = { workspace = true }
 bevy_mod_scripting_derive = { workspace = true }
-bevy_input = { version = "0.18.0", features = ["bevy_reflect", "gamepad", "gestures", "keyboard", "mouse", "smol_str", "std", "touch"], default-features = true}
+bevy_input = { version = "0.18.1", features = ["bevy_reflect", "gamepad", "gestures", "keyboard", "mouse", "smol_str", "std", "touch"], default-features = true}
 
 
 bevy_app = { version = "^0.18.0", features = ["bevy_reflect", "error_panic_hook", "reflect_auto_register", "std"], default-features = true}

--- a/crates/bindings/bevy_input_focus_bms_bindings/Cargo.toml
+++ b/crates/bindings/bevy_input_focus_bms_bindings/Cargo.toml
@@ -17,7 +17,7 @@ categories.workspace = true
 bevy_mod_scripting_core = { workspace = true }
 bevy_mod_scripting_bindings = { workspace = true }
 bevy_mod_scripting_derive = { workspace = true }
-bevy_input_focus = { version = "0.18.0", features = ["bevy_picking", "bevy_reflect", "gamepad", "keyboard", "mouse", "std"], default-features = true}
+bevy_input_focus = { version = "0.18.1", features = ["bevy_picking", "bevy_reflect", "gamepad", "keyboard", "mouse", "std"], default-features = true}
 
 
 bevy_app = { version = "^0.18.0", features = ["bevy_reflect", "error_panic_hook", "reflect_auto_register", "std"], default-features = true}

--- a/crates/bindings/bevy_light_bms_bindings/Cargo.toml
+++ b/crates/bindings/bevy_light_bms_bindings/Cargo.toml
@@ -17,7 +17,7 @@ categories.workspace = true
 bevy_mod_scripting_core = { workspace = true }
 bevy_mod_scripting_bindings = { workspace = true }
 bevy_mod_scripting_derive = { workspace = true }
-bevy_light = { version = "0.18.0", features = ["webgl"], default-features = true}
+bevy_light = { version = "0.18.1", features = ["webgl"], default-features = true}
 
 
 bevy_app = { version = "^0.18.0", features = ["bevy_reflect", "error_panic_hook", "reflect_auto_register", "std"], default-features = true}

--- a/crates/bindings/bevy_math_bms_bindings/Cargo.toml
+++ b/crates/bindings/bevy_math_bms_bindings/Cargo.toml
@@ -17,7 +17,7 @@ bevy_app = { workspace = true, features = ["std"] }
 bevy_mod_scripting_core = { workspace = true }
 bevy_mod_scripting_bindings = { workspace = true }
 bevy_mod_scripting_derive = { workspace = true }
-bevy_math = { version = "0.18.0", features = ["alloc", "bevy_reflect", "curve", "rand", "std"], default-features = true}
+bevy_math = { version = "0.18.1", features = ["alloc", "bevy_reflect", "curve", "rand", "std"], default-features = true}
 
 
 bevy_reflect = { version = "^0.18.0", features = ["auto_register", "auto_register_inventory", "debug", "debug_stack", "glam", "indexmap", "smallvec", "smol_str", "std", "uuid", "wgpu-types"], default-features = true}

--- a/crates/bindings/bevy_mesh_bms_bindings/Cargo.toml
+++ b/crates/bindings/bevy_mesh_bms_bindings/Cargo.toml
@@ -17,7 +17,7 @@ categories.workspace = true
 bevy_mod_scripting_core = { workspace = true }
 bevy_mod_scripting_bindings = { workspace = true }
 bevy_mod_scripting_derive = { workspace = true }
-bevy_mesh = { version = "0.18.0", features = ["bevy_mikktspace", "morph"], default-features = true}
+bevy_mesh = { version = "0.18.1", features = ["bevy_mikktspace", "morph"], default-features = true}
 
 
 bevy_app = { version = "^0.18.0", features = ["bevy_reflect", "error_panic_hook", "reflect_auto_register", "std"], default-features = true}

--- a/crates/bindings/bevy_pbr_bms_bindings/Cargo.toml
+++ b/crates/bindings/bevy_pbr_bms_bindings/Cargo.toml
@@ -17,7 +17,7 @@ categories.workspace = true
 bevy_mod_scripting_core = { workspace = true }
 bevy_mod_scripting_bindings = { workspace = true }
 bevy_mod_scripting_derive = { workspace = true }
-bevy_pbr = { version = "0.18.0", features = ["webgl"], default-features = true}
+bevy_pbr = { version = "0.18.1", features = ["webgl"], default-features = true}
 
 
 bevy_app = { version = "^0.18.0", features = ["bevy_reflect", "error_panic_hook", "reflect_auto_register", "std"], default-features = true}

--- a/crates/bindings/bevy_picking_bms_bindings/Cargo.toml
+++ b/crates/bindings/bevy_picking_bms_bindings/Cargo.toml
@@ -17,7 +17,7 @@ categories.workspace = true
 bevy_mod_scripting_core = { workspace = true }
 bevy_mod_scripting_bindings = { workspace = true }
 bevy_mod_scripting_derive = { workspace = true }
-bevy_picking = { version = "0.18.0", features = ["mesh_picking"], default-features = true}
+bevy_picking = { version = "0.18.1", features = ["mesh_picking"], default-features = true}
 
 
 bevy_app = { version = "^0.18.0", features = ["bevy_reflect", "error_panic_hook", "reflect_auto_register", "std"], default-features = true}

--- a/crates/bindings/bevy_post_process_bms_bindings/Cargo.toml
+++ b/crates/bindings/bevy_post_process_bms_bindings/Cargo.toml
@@ -17,7 +17,7 @@ categories.workspace = true
 bevy_mod_scripting_core = { workspace = true }
 bevy_mod_scripting_bindings = { workspace = true }
 bevy_mod_scripting_derive = { workspace = true }
-bevy_post_process = { version = "0.18.0", features = [], default-features = true}
+bevy_post_process = { version = "0.18.1", features = [], default-features = true}
 
 
 bevy_app = { version = "^0.18.0", features = ["bevy_reflect", "error_panic_hook", "reflect_auto_register", "std"], default-features = true}

--- a/crates/bindings/bevy_reflect_bms_bindings/Cargo.toml
+++ b/crates/bindings/bevy_reflect_bms_bindings/Cargo.toml
@@ -17,7 +17,7 @@ bevy_app = { workspace = true, features = ["std"] }
 bevy_mod_scripting_core = { workspace = true }
 bevy_mod_scripting_bindings = { workspace = true }
 bevy_mod_scripting_derive = { workspace = true }
-bevy_reflect = { version = "0.18.0", features = ["auto_register", "auto_register_inventory", "debug", "debug_stack", "glam", "indexmap", "smallvec", "smol_str", "std", "uuid", "wgpu-types"], default-features = true}
+bevy_reflect = { version = "0.18.1", features = ["auto_register", "auto_register_inventory", "debug", "debug_stack", "glam", "indexmap", "smallvec", "smol_str", "std", "uuid", "wgpu-types"], default-features = true}
 
 
 assert_type_match = { version = "^0.1.1", features = [], default-features = true}

--- a/crates/bindings/bevy_render_bms_bindings/Cargo.toml
+++ b/crates/bindings/bevy_render_bms_bindings/Cargo.toml
@@ -17,7 +17,7 @@ categories.workspace = true
 bevy_mod_scripting_core = { workspace = true }
 bevy_mod_scripting_bindings = { workspace = true }
 bevy_mod_scripting_derive = { workspace = true }
-bevy_render = { version = "0.18.0", features = ["morph", "multi_threaded", "webgl"], default-features = true}
+bevy_render = { version = "0.18.1", features = ["morph", "multi_threaded", "webgl"], default-features = true}
 
 
 async-channel = { version = "^2.3.0", features = [], default-features = true}

--- a/crates/bindings/bevy_scene_bms_bindings/Cargo.toml
+++ b/crates/bindings/bevy_scene_bms_bindings/Cargo.toml
@@ -17,7 +17,7 @@ categories.workspace = true
 bevy_mod_scripting_core = { workspace = true }
 bevy_mod_scripting_bindings = { workspace = true }
 bevy_mod_scripting_derive = { workspace = true }
-bevy_scene = { version = "0.18.0", features = ["serialize"], default-features = true}
+bevy_scene = { version = "0.18.1", features = ["serialize"], default-features = true}
 
 
 bevy_app = { version = "^0.18.0", features = ["bevy_reflect", "error_panic_hook", "reflect_auto_register", "std"], default-features = true}

--- a/crates/bindings/bevy_sprite_bms_bindings/Cargo.toml
+++ b/crates/bindings/bevy_sprite_bms_bindings/Cargo.toml
@@ -17,7 +17,7 @@ categories.workspace = true
 bevy_mod_scripting_core = { workspace = true }
 bevy_mod_scripting_bindings = { workspace = true }
 bevy_mod_scripting_derive = { workspace = true }
-bevy_sprite = { version = "0.18.0", features = ["bevy_picking", "bevy_text", "bevy_window"], default-features = true}
+bevy_sprite = { version = "0.18.1", features = ["bevy_picking", "bevy_text", "bevy_window"], default-features = true}
 
 
 bevy_app = { version = "^0.18.0", features = ["bevy_reflect", "error_panic_hook", "reflect_auto_register", "std"], default-features = true}

--- a/crates/bindings/bevy_sprite_render_bms_bindings/Cargo.toml
+++ b/crates/bindings/bevy_sprite_render_bms_bindings/Cargo.toml
@@ -17,7 +17,7 @@ categories.workspace = true
 bevy_mod_scripting_core = { workspace = true }
 bevy_mod_scripting_bindings = { workspace = true }
 bevy_mod_scripting_derive = { workspace = true }
-bevy_sprite_render = { version = "0.18.0", features = ["bevy_text", "webgl"], default-features = true}
+bevy_sprite_render = { version = "0.18.1", features = ["bevy_text", "webgl"], default-features = true}
 
 
 bevy_app = { version = "^0.18.0", features = ["bevy_reflect", "error_panic_hook", "reflect_auto_register", "std"], default-features = true}

--- a/crates/bindings/bevy_text_bms_bindings/Cargo.toml
+++ b/crates/bindings/bevy_text_bms_bindings/Cargo.toml
@@ -17,7 +17,7 @@ categories.workspace = true
 bevy_mod_scripting_core = { workspace = true }
 bevy_mod_scripting_bindings = { workspace = true }
 bevy_mod_scripting_derive = { workspace = true }
-bevy_text = { version = "0.18.0", features = ["default_font"], default-features = true}
+bevy_text = { version = "0.18.1", features = ["default_font"], default-features = true}
 
 
 bevy_app = { version = "^0.18.0", features = ["bevy_reflect", "error_panic_hook", "reflect_auto_register", "std"], default-features = true}

--- a/crates/bindings/bevy_time_bms_bindings/Cargo.toml
+++ b/crates/bindings/bevy_time_bms_bindings/Cargo.toml
@@ -17,7 +17,7 @@ categories.workspace = true
 bevy_mod_scripting_core = { workspace = true }
 bevy_mod_scripting_bindings = { workspace = true }
 bevy_mod_scripting_derive = { workspace = true }
-bevy_time = { version = "0.18.0", features = ["bevy_reflect", "std"], default-features = true}
+bevy_time = { version = "0.18.1", features = ["bevy_reflect", "std"], default-features = true}
 
 
 bevy_app = { version = "^0.18.0", features = ["bevy_reflect", "error_panic_hook", "reflect_auto_register", "std"], default-features = true}

--- a/crates/bindings/bevy_transform_bms_bindings/Cargo.toml
+++ b/crates/bindings/bevy_transform_bms_bindings/Cargo.toml
@@ -17,7 +17,7 @@ categories.workspace = true
 bevy_mod_scripting_core = { workspace = true }
 bevy_mod_scripting_bindings = { workspace = true }
 bevy_mod_scripting_derive = { workspace = true }
-bevy_transform = { version = "0.18.0", features = ["alloc", "async_executor", "bevy-support", "bevy_log", "bevy_reflect", "std"], default-features = true}
+bevy_transform = { version = "0.18.1", features = ["alloc", "async_executor", "bevy-support", "bevy_log", "bevy_reflect", "std"], default-features = true}
 
 
 bevy_app = { version = "^0.18.0", features = ["bevy_reflect", "error_panic_hook", "reflect_auto_register", "std"], default-features = true}

--- a/crates/bindings/bevy_ui_bms_bindings/Cargo.toml
+++ b/crates/bindings/bevy_ui_bms_bindings/Cargo.toml
@@ -17,7 +17,7 @@ categories.workspace = true
 bevy_mod_scripting_core = { workspace = true }
 bevy_mod_scripting_bindings = { workspace = true }
 bevy_mod_scripting_derive = { workspace = true }
-bevy_ui = { version = "0.18.0", features = ["bevy_picking"], default-features = true}
+bevy_ui = { version = "0.18.1", features = ["bevy_picking"], default-features = true}
 
 
 accesskit = { version = "^0.21", features = [], default-features = true}

--- a/crates/bindings/bevy_ui_render_bms_bindings/Cargo.toml
+++ b/crates/bindings/bevy_ui_render_bms_bindings/Cargo.toml
@@ -17,7 +17,7 @@ categories.workspace = true
 bevy_mod_scripting_core = { workspace = true }
 bevy_mod_scripting_bindings = { workspace = true }
 bevy_mod_scripting_derive = { workspace = true }
-bevy_ui_render = { version = "0.18.0", features = [], default-features = true}
+bevy_ui_render = { version = "0.18.1", features = [], default-features = true}
 
 
 bevy_app = { version = "^0.18.0", features = ["bevy_reflect", "error_panic_hook", "reflect_auto_register", "std"], default-features = true}

--- a/crates/lad_backends/lua_language_server_lad_backend/src/convert.rs
+++ b/crates/lad_backends/lua_language_server_lad_backend/src/convert.rs
@@ -56,7 +56,7 @@ pub fn convert_ladfile_to_lua_declaration_file(
         // .ok_or_else(|| anyhow::anyhow!("Lua class not found for type ID: {}", type_id))?;
         definition_file.modules.push(LuaModule {
             name: lad_type.identifier.to_owned(),
-            classes: vec![lua_class.clone()],
+            class: Some(lua_class.clone()),
             functions,
             ..Default::default()
         });
@@ -93,6 +93,24 @@ pub fn convert_ladfile_to_lua_declaration_file(
                 definition: class,
                 description: Some(description.into()),
             })
+    }
+
+    for (_, function) in ladfile
+        .functions
+        .iter()
+        .filter(|(_, function)| function.namespace.is_global())
+    {
+        let converted = match lad_function_to_lua_function(ladfile, function) {
+            Ok(converted) => converted,
+            Err(err) => {
+                log::warn!(
+                    "Error generating global function {}: {err}. Ignoring function.",
+                    function.identifier,
+                );
+                continue;
+            }
+        };
+        globals_module.functions.push(converted)
     }
     definition_file.modules.push(globals_module);
 
@@ -376,15 +394,15 @@ pub fn lad_function_to_lua_function(
                 .as_ref()
                 .map(|v| v.to_string())
                 .unwrap_or(format!("p{}", idx + 1));
-            Ok(FunctionParam {
-                name: match ForbiddenKeywords::is_forbidden_err(&ident) {
+            Ok(FunctionParam::new(
+                match ForbiddenKeywords::is_forbidden_err(&ident) {
                     Ok(_) => ident,
                     Err(_) => format!("_{ident}"),
                 },
-                ty: lad_instance_to_lua_type(ladfile, &a.kind)?,
-                optional: matches!(a.kind, LadFieldOrVariableKind::Option(..)),
-                description: a.documentation.as_ref().map(|d| d.to_string()),
-            })
+                lad_instance_to_lua_type(ladfile, &a.kind)?,
+                matches!(a.kind, LadFieldOrVariableKind::Option(..)),
+                a.documentation.as_ref().map(|d| d.to_string()),
+            ))
         })
         .collect::<Result<Vec<_>, anyhow::Error>>()?;
 
@@ -472,6 +490,9 @@ pub fn lad_instance_to_lua_type(
                 LuaType::Tuple(to_lua_many(ladfile, lad_type_kinds)?)
             }
         }
+        ladfile::LadFieldOrVariableKind::UntypedTuple => LuaType::Variadic(Box::new(
+            lad_primitive_to_lua_type(&ReflectionPrimitiveKind::ScriptValue),
+        )),
         ladfile::LadFieldOrVariableKind::Array(lad_type_kind, _) => {
             LuaType::Array(Box::new(lad_instance_to_lua_type(ladfile, lad_type_kind)?))
         }

--- a/crates/lad_backends/lua_language_server_lad_backend/src/lua_declaration_file.rs
+++ b/crates/lad_backends/lua_language_server_lad_backend/src/lua_declaration_file.rs
@@ -80,6 +80,7 @@ pub enum LuaType {
     Union(Vec<LuaType>),
     Array(Box<LuaType>),
     Tuple(Vec<LuaType>),
+    Variadic(Box<LuaType>), // should be converted to varargs
     Dictionary {
         key: Box<LuaType>,
         value: Box<LuaType>,
@@ -113,8 +114,26 @@ pub struct FunctionSignatureShort {
 pub struct FunctionParam {
     pub name: String,
     pub ty: LuaType,
+    pub variadic: bool,
     pub optional: bool,
     pub description: Option<String>,
+}
+
+impl FunctionParam {
+    pub fn new(
+        name: String,
+        ty: LuaType,
+        optional: bool,
+        description: Option<String>,
+    ) -> FunctionParam {
+        Self {
+            name,
+            variadic: matches!(ty, LuaType::Variadic(_)),
+            ty,
+            optional,
+            description,
+        }
+    }
 }
 
 /// Represents a function signature with comprehensive annotation support.
@@ -351,7 +370,7 @@ pub struct TypeInstance {
 #[derive(Debug, Clone, Serialize, Default)]
 pub struct LuaModule {
     pub name: String,
-    pub classes: Vec<LuaClass>,
+    pub class: Option<LuaClass>,
     pub globals: Vec<TypeInstance>,
     pub functions: Vec<FunctionSignature>,
     pub documentation: Option<String>,

--- a/crates/lad_backends/lua_language_server_lad_backend/src/templating.rs
+++ b/crates/lad_backends/lua_language_server_lad_backend/src/templating.rs
@@ -13,18 +13,18 @@ pub fn prepare_tera() -> Result<tera::Tera, anyhow::Error> {
 
         let template_name = file.path().to_string_lossy();
         tera.add_raw_template(&template_name, content_utf8)
-            .map_err(handle_tera_error)?;
+            .map_err(|arg: tera::Error| handle_tera_error(&arg))?;
     }
 
     Ok(tera)
 }
 
-fn handle_tera_error(error: tera::Error) -> anyhow::Error {
+fn handle_tera_error(error: &dyn Error) -> anyhow::Error {
     let inner_error_str = error
         .source()
-        .and_then(|e| e.to_string().into())
-        .unwrap_or_else(|| "No source available".to_string());
-    anyhow::anyhow!("Tera error: {error}, {inner_error_str}")
+        .map(|e| handle_tera_error(e).to_string())
+        .unwrap_or_default();
+    anyhow::anyhow!("{error}\n{inner_error_str}")
 }
 
 pub fn render_template(
@@ -36,5 +36,5 @@ pub fn render_template(
         log::trace!("Available template: {name}");
     });
     tera.render(template_name, context)
-        .map_err(handle_tera_error)
+        .map_err(|arg: tera::Error| handle_tera_error(&arg))
 }

--- a/crates/lad_backends/lua_language_server_lad_backend/templates/declaration_file.tera
+++ b/crates/lad_backends/lua_language_server_lad_backend/templates/declaration_file.tera
@@ -3,16 +3,17 @@
 {# newline #}
 {# newline #}
 {%- for module in modules -%} {# module #}
-{%- for class in module.classes -%}
----@class {{ class.name }} {%- if class.parents %} : {% endif -%}{%- for parent in class.parents -%}{{parent}}{%- if not loop.last-%},{%- endif -%}{%- endfor %}
-{{ self::multiline_description(description=class.documentation) -}}
-{%- for field in class.fields -%}
+{%- if module.class -%} {# class #}
+---@class {{ module.class.name }} {%- if module.class.parents %} : {% endif -%}{%- for parent in module.class.parents -%}{{parent}}{%- if not loop.last-%},{%- endif -%}{%- endfor %}
+{{ self::multiline_description(description=module.class.documentation) -}}
+{%- for field in module.class.fields -%}
 {{- self::class_field(field=field) -}}
 {%- endfor -%} {#- fields -#}
-{%- for operator in class.operators -%}
+{%- for operator in module.class.operators -%}
 ---@operator {{operator.operation}}{% if operator.param_type %}({{self::lua_type(ty=operator.param_type)}}){% endif %}: {{self::lua_type(ty=operator.return_type)}}
 {% endfor -%}
-{{ class.name }} = {}
+{{ module.class.name }} = {}
+{%- endif -%} {# class #}
 {# newline #}
 {%- for function in module.functions -%}
 {# newline #}
@@ -41,16 +42,15 @@
 {{- self::function_param(arg=param) -}}
 {%- endfor -%}
 {%- for return in function.returns -%}
----@return {{ self::lua_type(ty=return) }}
-function {% if function.has_self -%}{{class.name}}:{%- else -%}{{class.name}}.{%- endif -%} {{ function.name }}(
+---@return {{ self::lua_type(ty=return, return_position=true) }}
+function {% if module.class -%}{%- if function.has_self -%}{{module.class.name}}:{%- else -%}{{module.class.name}}.{%- endif -%}{%- endif -%} {{ function.name }}(
     {%- for param in function.params -%}
-        {{ param.name }} {%- if not loop.last -%},{%- endif -%}
+        {% if param.variadic -%}... {% endif-%}{{ param.name }} {%- if not loop.last -%},{%- endif -%}
     {%- endfor -%}
 ) end
 {# newline #}
 {%- endfor -%}
 {%- endfor -%} {# functions #}
-{%- endfor -%} {# class #}
 {# newline #}
 {# newline #}
 {%- for global in module.globals -%}
@@ -69,7 +69,7 @@ function {% if function.has_self -%}{{class.name}}:{%- else -%}{{class.name}}.{%
 {# newline -#}
 {%- endmacro class_field -%}
 
-{%- macro lua_type(ty) -%}
+{%- macro lua_type(ty, return_position=false) -%}
     {%- if ty.kind == "Primitive" -%}
         {{ ty.value }}
     {%- elif ty.kind == "Alias" -%}
@@ -92,6 +92,12 @@ function {% if function.has_self -%}{{class.name}}:{%- else -%}{{class.name}}.{%
             {%- if not loop.last %}, {% endif -%}
         {%- endfor -%}
         ]
+    {%- elif ty.kind == "Variadic" -%}
+        {%- if return_position -%}
+        {{- self::lua_type(ty=ty.value) }} ...
+        {%- else -%}
+        ... {{ self::lua_type(ty=ty.value) -}}
+        {%- endif -%}
     {%- elif ty.kind == "Dictionary" -%}
         table<{{ self::lua_type(ty=ty.value.key) }}, {{ self::lua_type(ty=ty.value.value) }}>
     {%- elif ty.kind == "Function" -%}

--- a/crates/lad_backends/lua_language_server_lad_backend/tests/example_ladfile/expected.lua
+++ b/crates/lad_backends/lua_language_server_lad_backend/tests/example_ladfile/expected.lua
@@ -1,6 +1,7 @@
 ---@meta
 ---@module "PlainStructType"
 
+
 ---@class PlainStructType : ReflectReference
 ---  I am a simple plain struct type
 ---@field  int_field ? integer
@@ -12,9 +13,11 @@ PlainStructType = {}
 function PlainStructType:plain_struct_function(p1,p2) end
 
 
+
 ---@class Bool
 --- A boolean value
 Bool = {}
+
 
 
 ---@class Char
@@ -22,9 +25,11 @@ Bool = {}
 Char = {}
 
 
+
 ---@class DynamicFunction
 --- A callable dynamic function
 DynamicFunction = {}
+
 
 
 ---@class DynamicFunctionMut
@@ -32,9 +37,11 @@ DynamicFunction = {}
 DynamicFunctionMut = {}
 
 
+
 ---@class F32
 --- A 32-bit floating point number
 F32 = {}
+
 
 
 ---@class F64
@@ -42,9 +49,11 @@ F32 = {}
 F64 = {}
 
 
+
 ---@class FunctionCallContext
 --- Function call context, if accepted by a function, means the function can access the world in arbitrary ways.
 FunctionCallContext = {}
+
 
 
 ---@class I128
@@ -52,9 +61,11 @@ FunctionCallContext = {}
 I128 = {}
 
 
+
 ---@class I16
 --- A signed 16-bit integer
 I16 = {}
+
 
 
 ---@class I32
@@ -62,9 +73,11 @@ I16 = {}
 I32 = {}
 
 
+
 ---@class I64
 --- A signed 64-bit integer
 I64 = {}
+
 
 
 ---@class I8
@@ -72,9 +85,11 @@ I64 = {}
 I8 = {}
 
 
+
 ---@class Isize
 --- A signed pointer-sized integer
 Isize = {}
+
 
 
 ---@class OsString
@@ -82,9 +97,11 @@ Isize = {}
 OsString = {}
 
 
+
 ---@class PathBuf
 --- A heap allocated file path
 PathBuf = {}
+
 
 
 ---@class ReflectReference
@@ -92,9 +109,11 @@ PathBuf = {}
 ReflectReference = {}
 
 
+
 ---@class ScriptValue
 --- A value representing the union of all representable values
 ScriptValue = {}
+
 
 
 ---@class Str
@@ -102,9 +121,11 @@ ScriptValue = {}
 Str = {}
 
 
+
 ---@class String
 --- A heap allocated string
 String = {}
+
 
 
 ---@class U128
@@ -112,9 +133,11 @@ String = {}
 U128 = {}
 
 
+
 ---@class U16
 --- An unsigned 16-bit integer
 U16 = {}
+
 
 
 ---@class U32
@@ -122,9 +145,11 @@ U16 = {}
 U32 = {}
 
 
+
 ---@class U64
 --- An unsigned 64-bit integer
 U64 = {}
+
 
 
 ---@class U8
@@ -132,13 +157,16 @@ U64 = {}
 U8 = {}
 
 
+
 ---@class Usize
 --- An unsigned pointer-sized integer
 Usize = {}
 
 
+
 ---@class EnumType : ReflectReference
 EnumType = {}
+
 
 
 ---@class TupleStructType : ReflectReference
@@ -148,11 +176,17 @@ EnumType = {}
 TupleStructType = {}
 
 
+
 ---@class UnitType : ReflectReference
 ---  I am a unit test type
 UnitType = {}
 
 
+
+
+---@param arg1 integer 
+---@return integer
+function hello_world(arg1) end
 
 
 ---@type any

--- a/crates/ladfile/src/lib.rs
+++ b/crates/ladfile/src/lib.rs
@@ -242,6 +242,13 @@ pub enum LadFunctionNamespace {
     Global,
 }
 
+impl LadFunctionNamespace {
+    /// Retruns true if the namespace is the global namespace
+    pub fn is_global(&self) -> bool {
+        matches!(self, LadFunctionNamespace::Global)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 /// An argument definition used in a LAD file.
 pub struct LadArgument {
@@ -287,6 +294,8 @@ pub enum LadFieldOrVariableKind {
     InteropResult(Box<LadFieldOrVariableKind>),
     /// A tuple of arguments
     Tuple(Vec<LadFieldOrVariableKind>),
+    /// A variadic tuple
+    UntypedTuple,
     /// An array
     Array(Box<LadFieldOrVariableKind>, usize),
     /// A primitive type, implementing `IntoScript` and `FromScript` natively in BMS.
@@ -332,6 +341,9 @@ pub trait ArgumentVisitor {
     fn visit_unknown(&mut self, type_id: &LadTypeId) {
         self.visit_lad_type_id(type_id);
     }
+
+    /// Visits an untyped tuple
+    fn visit_untyped_tuple(&mut self) {}
 
     /// walks the lad type_id structure, by default simply visits type_id's
     /// Can be used to dispatch to primitives instead of the type maps to these
@@ -431,6 +443,7 @@ pub trait ArgumentVisitor {
             }
             LadFieldOrVariableKind::Union(inner) => self.walk_union(inner),
             LadFieldOrVariableKind::Unknown(type_id) => self.walk_unknown(type_id),
+            LadFieldOrVariableKind::UntypedTuple => self.visit_untyped_tuple(),
         }
     }
 }

--- a/crates/ladfile_builder/src/lib.rs
+++ b/crates/ladfile_builder/src/lib.rs
@@ -450,6 +450,7 @@ impl<'t> LadFileBuilder<'t> {
                         self.add_through_type_info(ti);
                     }
                 }
+                TypedWrapperKind::UntypedTuple => {}
             },
             ThroughTypeInfo::TypeInfo(type_info) => {
                 self.add_type_info(type_info);
@@ -972,6 +973,7 @@ impl<'t> LadFileBuilder<'t> {
                         })
                         .collect(),
                 ),
+                TypedWrapperKind::UntypedTuple => LadFieldOrVariableKind::UntypedTuple,
             },
             ThroughTypeInfo::TypeInfo(type_info) => {
                 match primitive_from_type_id(type_info.type_id()) {

--- a/crates/ladfile_builder/src/plugin.rs
+++ b/crates/ladfile_builder/src/plugin.rs
@@ -203,7 +203,7 @@ pub fn generate_lad_file(
     for processor in settings.processors.iter() {
         bevy_log::info!("Running ladfile processor: '{}'", processor.name());
         if let Err(e) = processor.run(&file, directory) {
-            bevy_log::error!("Error in running ladfile processor: {e}")
+            bevy_log::error!("Error in running ladfile processor: {e:#}")
         }
     }
 

--- a/crates/languages/bevy_mod_scripting_lua/src/bindings/script_value.rs
+++ b/crates/languages/bevy_mod_scripting_lua/src/bindings/script_value.rs
@@ -5,15 +5,75 @@ use std::{
 
 use bevy_mod_scripting_asset::Language;
 use bevy_mod_scripting_bindings::{
-    LocationContext, error::InteropError, function::script_function::FunctionCallContext,
-    script_value::ScriptValue,
+    LocationContext, VariadicTuple, error::InteropError,
+    function::script_function::FunctionCallContext, script_value::ScriptValue,
 };
 use bevy_platform::collections::HashMap;
-use mlua::{FromLua, IntoLua, Value, Variadic};
+use mlua::{FromLua, FromLuaMulti, IntoLua, IntoLuaMulti, MultiValue, Value};
 
 use crate::{IntoMluaError, LuaContextAppData};
 
 use super::reference::LuaReflectReference;
+
+/// A wrapper around many [`ScriptValue`]'s, used where the potential to return/receive many values separately arises.
+pub struct MultiLuaScriptValue(pub VecDeque<ScriptValue>);
+
+impl MultiLuaScriptValue {
+    /// Coalesces the many values as interpreted by lua to a single script value from the bms framework
+    pub fn into_script_value(mut self) -> ScriptValue {
+        if self.0.is_empty() {
+            ScriptValue::Unit
+        } else if let Some(first) = self.0.pop_front()
+            && self.0.len() == 1
+        {
+            first
+        } else {
+            ScriptValue::Tuple(VariadicTuple(self.0))
+        }
+    }
+
+    /// Interprets a bms framework value as potentially multiple values in lua
+    pub fn from_script_value(value: ScriptValue) -> Self {
+        if let ScriptValue::Tuple(VariadicTuple(tuple)) = value {
+            Self(tuple)
+        } else {
+            MultiLuaScriptValue(VecDeque::from_iter([value]))
+        }
+    }
+}
+
+impl FromLuaMulti for MultiLuaScriptValue {
+    fn from_lua_multi(values: mlua::MultiValue, lua: &mlua::Lua) -> mlua::Result<Self> {
+        let mut vals = VecDeque::with_capacity(values.len());
+        for val in values {
+            let script_val = LuaScriptValue::from_lua(val, lua)?;
+            vals.push_back(script_val.into());
+        }
+        Ok(MultiLuaScriptValue(vals))
+    }
+}
+
+impl IntoLuaMulti for MultiLuaScriptValue {
+    fn into_lua_multi(self, lua: &mlua::Lua) -> mlua::Result<mlua::MultiValue> {
+        let mut vals = MultiValue::with_capacity(self.0.len());
+        let mut left = self.0.len();
+        for val in self.0 {
+            left -= 1;
+            // tuples can get destructured into many vals if they are the last in the collection
+            match val {
+                ScriptValue::Tuple(VariadicTuple(tuple)) if left == 0 => {
+                    let mut many_vals = MultiLuaScriptValue(tuple).into_lua_multi(lua)?;
+                    vals.append(&mut many_vals);
+                }
+                _ => {
+                    let mlua_val = LuaScriptValue(val).into_lua(lua)?;
+                    vals.push_back(mlua_val);
+                }
+            }
+        }
+        Ok(vals)
+    }
+}
 
 #[derive(Debug, Clone)]
 /// A wrapper around a [`ScriptValue`] that implements [`FromLua`] and [`IntoLua`]
@@ -59,12 +119,8 @@ impl FromLua for LuaScriptValue {
             Value::String(s) => ScriptValue::String(s.to_str()?.to_owned().into()),
             Value::Function(f) => ScriptValue::Function(
                 (move |_context: FunctionCallContext, args: VecDeque<ScriptValue>| {
-                    match f.call::<LuaScriptValue>(
-                        args.into_iter()
-                            .map(LuaScriptValue)
-                            .collect::<Variadic<_>>(),
-                    ) {
-                        Ok(v) => v.0,
+                    match f.call::<MultiLuaScriptValue>(MultiLuaScriptValue(args)) {
+                        Ok(v) => v.into_script_value(),
                         Err(e) => ScriptValue::Error(InteropError::external(Box::new(e))),
                     }
                 })
@@ -89,15 +145,15 @@ impl FromLua for LuaScriptValue {
                             return Ok(LuaScriptValue::from(ScriptValue::Map(map)));
                         } else {
                             // if the key is an integer, then it's a list
-                            let mut vec = Vec::with_capacity(table.len()? as usize);
-                            vec.push(v.into());
+                            let mut vec = VecDeque::with_capacity(table.len()? as usize);
+                            vec.push_back(v.into());
                             for pair in iter {
-                                vec.push(pair?.1.into());
+                                vec.push_back(pair?.1.into());
                             }
                             return Ok(LuaScriptValue::from(ScriptValue::List(vec)));
                         }
                     }
-                    None => return Ok(LuaScriptValue::from(ScriptValue::List(vec![]))),
+                    None => return Ok(LuaScriptValue::from(ScriptValue::List(Default::default()))),
                 }
             }
             // Value::Thread(thread) => todo!(),
@@ -140,7 +196,7 @@ impl IntoLua for LuaScriptValue {
             ScriptValue::Reference(r) => LuaReflectReference::from(r).into_lua(lua)?,
             ScriptValue::Error(script_error) => return Err(mlua::Error::external(script_error)),
             ScriptValue::Function(function) => lua
-                .create_function(move |lua, args: Variadic<LuaScriptValue>| {
+                .create_function(move |lua, args: MultiLuaScriptValue| {
                     let loc = {
                         profiling::scope!("function call context");
                         lua.inspect_stack(1).map(|debug| LocationContext {
@@ -153,16 +209,16 @@ impl IntoLua for LuaScriptValue {
                     };
                     let out = function
                         .call(
-                            args.into_iter().map(Into::into),
+                            args.0,
                             FunctionCallContext::new_with_location(Language::Lua, loc),
                         )
                         .map_err(IntoMluaError::to_lua_error)?;
 
-                    Ok(LuaScriptValue::from(out))
+                    Ok(MultiLuaScriptValue::from_script_value(out))
                 })?
                 .into_lua(lua)?,
             ScriptValue::FunctionMut(function) => lua
-                .create_function(move |lua, args: Variadic<LuaScriptValue>| {
+                .create_function(move |lua, args: MultiLuaScriptValue| {
                     let loc = {
                         profiling::scope!("function call context");
                         lua.inspect_stack(1).map(|debug| LocationContext {
@@ -175,15 +231,16 @@ impl IntoLua for LuaScriptValue {
                     };
                     let out = function
                         .call(
-                            args.into_iter().map(Into::into),
+                            args.0,
                             FunctionCallContext::new_with_location(Language::Lua, loc),
                         )
                         .map_err(IntoMluaError::to_lua_error)?;
 
-                    Ok(LuaScriptValue::from(out))
+                    Ok(MultiLuaScriptValue::from_script_value(out))
                 })?
                 .into_lua(lua)?,
-            ScriptValue::List(vec) => {
+            // when we encounter a tuple here, we can't convert to many args, so just return a table
+            ScriptValue::List(vec) | ScriptValue::Tuple(VariadicTuple(vec)) => {
                 let table = lua.create_table_from(
                     vec.into_iter()
                         .enumerate()

--- a/crates/languages/bevy_mod_scripting_rhai/src/bindings/script_value.rs
+++ b/crates/languages/bevy_mod_scripting_rhai/src/bindings/script_value.rs
@@ -1,7 +1,8 @@
-use std::str::FromStr;
+use std::{collections::VecDeque, str::FromStr};
 
 use bevy_mod_scripting_asset::Language;
 use bevy_mod_scripting_bindings::{
+    VariadicTuple,
     error::InteropError,
     function::script_function::{DynamicScriptFunction, FunctionCallContext},
     script_value::ScriptValue,
@@ -80,8 +81,8 @@ impl IntoDynamic for ScriptValue {
                     .into(),
                 )
             })?,
-            ScriptValue::List(_vec) => Dynamic::from_array(
-                _vec.into_iter()
+            ScriptValue::List(vec) | ScriptValue::Tuple(VariadicTuple(vec)) => Dynamic::from_array(
+                vec.into_iter()
                     .map(|v| v.into_dynamic())
                     .collect::<Result<Vec<_>, _>>()?,
             ),
@@ -173,7 +174,7 @@ impl FromDynamic for ScriptValue {
                     .map_err(IntoRhaiError::into_rhai_error)?
                     .into_iter()
                     .map(ScriptValue::from_dynamic)
-                    .collect::<Result<Vec<_>, _>>()?,
+                    .collect::<Result<VecDeque<_>, _>>()?,
             )),
             d => {
                 let type_name = d.type_name();

--- a/docs/src/ReleaseNotes/0.19-to-0.20.md
+++ b/docs/src/ReleaseNotes/0.19-to-0.20.md
@@ -38,3 +38,7 @@ You should use: `V<T>`, `R<T>` and `M<T>` instead
 > M<T>
 < Mut<T>
 ```
+
+## `ScriptValue::List` changes
+
+This variant now uses `VecDeque` instead of `Vec`

--- a/docs/src/ReleaseNotes/0.20.0.md
+++ b/docs/src/ReleaseNotes/0.20.0.md
@@ -30,4 +30,15 @@ You should use: `V<T>`, `R<T>` and `M<T>` instead
 
 ## Addition of logging bindings
 
-Standard `info`, `debug`, `trace`, `warn` and `error` functions are now available in scripts by default
+Standard `log_info`, `log_debug`, `log_trace`, `log_warn` and `log_error` functions are now available in scripts by default
+
+## Variadic bindings & Support for multiple return values
+
+The `ArgMeta` trait now includes: `variadic() -> bool` which if true, allows an argument in a binding to capture all remaining arguments from the call (effectively only usable as the last argument).
+
+This is implemented by the brand new `VariadicTuple` type, which is an untyped wrapper for a variable amount of non-homogenous values.
+
+New variants in the `TypedThrough` and `LAD` file format have ben added to represent variadics, and lua definition files generated from these will support them.
+
+Two bindings have been added: `pack_args` and `unpack_args` to allow script code to directly create/unpack tuple variants if necessary. However for languages like Lua, supporting multiple return values, `ScriptValue::Tuple` variants (which is what we produce to represent variadic returns), are converted to many return values naturally.
+

--- a/docs/src/ReleaseNotes/0.20.0.md
+++ b/docs/src/ReleaseNotes/0.20.0.md
@@ -42,3 +42,6 @@ New variants in the `TypedThrough` and `LAD` file format have ben added to repre
 
 Two bindings have been added: `pack_args` and `unpack_args` to allow script code to directly create/unpack tuple variants if necessary. However for languages like Lua, supporting multiple return values, `ScriptValue::Tuple` variants (which is what we produce to represent variadic returns), are converted to many return values naturally.
 
+# New `VecDeque` impls
+
+`VecDeque` now implements various BMS traits and can be used in bindings as a normal argument.


### PR DESCRIPTION
# Summary

Adds variadic support to all bindings, as well as support for multiple return values via addition of `ScriptValue::Tuple`.

Fixes #420.

I've considered another approach, and got far with it but ultimately didn't like the implications. I.e. We could have had a `FromLuaMulti`, `IntoLuaMulti` equivalent to mlua's, meaning we support multiple values natively but only at the very top level, however that complicates a lot of our API surface. Having the assurance that we only ever produce one value in binding code is nice (it just means we have to interprete tuple returns to support variadics) 

