### PR TITLE
fix: script systems unable to be added when bevy debug feature is disabled

### DIFF
--- a/assets/tests/add_system/added_systems_run_in_parallel.lua
+++ b/assets/tests/add_system/added_systems_run_in_parallel.lua
@@ -11,11 +11,15 @@ function on_test()
     :after(test_system)
   )
 
+  assert_str_eq(system_a:identifier(), "custom_system_a")
+
   local system_b = world.add_system(
     post_update_schedule,
     system_builder("custom_system_b", script_attachment)
     :after(test_system)
   )
+
+  assert_str_eq(system_b:identifier(), "custom_system_b")
 
   -- generate a schedule graph and verify it's what we expect
   local dot_graph = post_update_schedule:render_dot()

--- a/crates/bevy_mod_scripting_core/src/script_system.rs
+++ b/crates/bevy_mod_scripting_core/src/script_system.rs
@@ -34,9 +34,7 @@ use bevy_mod_scripting_world::{WorldAccessGuard, WorldAccessRange, WorldGuard};
 use bevy_reflect::TypeRegistryArc;
 use bevy_system_reflection::{ReflectSchedule, ReflectSystem};
 use bevy_utils::prelude::DebugName;
-use std::{
-    any::TypeId, borrow::Cow, collections::HashSet, hash::Hash, marker::PhantomData, ops::Deref,
-};
+use std::{any::TypeId, borrow::Cow, collections::HashSet, hash::Hash, marker::PhantomData};
 #[derive(Clone, Hash, PartialEq, Eq)]
 /// a system set for script systems.
 pub struct ScriptSystemSet(Cow<'static, str>);
@@ -142,7 +140,6 @@ impl ScriptSystemBuilder {
             // it immediately calls a singular script with a predefined payload
             let before_systems = self.before.clone();
             let after_systems = self.after.clone();
-            let system_name = self.name.to_string();
 
             // this is quite important, by default systems are placed in a set defined by their TYPE, i.e. in this case
             // all script systems would be the same
@@ -174,7 +171,7 @@ impl ScriptSystemBuilder {
             let (node_id, system) = schedule
                 .systems()
                 .map_err(InteropError::external)?
-                .find(|(_, b)| b.name().deref() == system_name)
+                .max_by_key(|(n, _)| *n)
                 .ok_or_else(|| InteropError::invariant("After adding the system, it was not found in the schedule, could not return a reference to it"))?;
             Ok(ReflectSystem::from_system(system.as_ref(), node_id))
         })?

--- a/crates/bevy_mod_scripting_core/src/script_system.rs
+++ b/crates/bevy_mod_scripting_core/src/script_system.rs
@@ -214,7 +214,7 @@ pub enum ScriptSystemParam {
 
 /// A system specified, created, and added by a script
 pub struct DynamicScriptSystem<P: IntoScriptPluginParams> {
-    name: DebugName,
+    name: Cow<'static, str>,
     exclusive: bool,
     pub(crate) last_run: Tick,
     target_attachment: ScriptAttachment,
@@ -252,7 +252,7 @@ impl<P: IntoScriptPluginParams> System for DynamicScriptSystem<P> {
     type Out = ();
 
     fn name(&self) -> DebugName {
-        self.name.clone()
+        self.name.clone().into()
     }
 
     fn flags(&self) -> SystemStateFlags {


### PR DESCRIPTION
# Summary
Script systems rely on the system name as an identifier when added to the schedule (so we can retrieve them as bevy doesn't return the SystemId).

When bevy `debug` is off, this just doesn't get stored, so we fail to identify the system.

We can in theory just refer to the Highest NodeID, although this assumption might break in the future. For now this will fix the problem