### PR TITLE
fix: Improve pipeline robustness, allow same frame attach + detach events.

### DIFF
--- a/assets/tests/lifecycle/default/entity_script/load_unload_one_frame/lifecycle.lua
+++ b/assets/tests/lifecycle/default/entity_script/load_unload_one_frame/lifecycle.lua
@@ -1,0 +1,11 @@
+function on_script_loaded()
+    return "loaded!"
+end
+
+function on_script_unloaded()
+    return "unloaded!"
+end
+
+function on_script_reloaded(val)
+    return "reloaded with: " .. val
+end

--- a/assets/tests/lifecycle/default/entity_script/load_unload_one_frame/scenario.bmsscenario
+++ b/assets/tests/lifecycle/default/entity_script/load_unload_one_frame/scenario.bmsscenario
@@ -1,0 +1,16 @@
+SetCurrentLanguage language="@this_script_language"
+InstallPlugin emit_responses=true
+FinalizeApp
+
+// load script a 
+LoadScriptAs as_name="script_a", path="lifecycle.lua"
+WaitForScriptAssetLoaded name="script_a"
+SpawnEntityWithScript name="test_entity_a", script="script_a"
+// now despawn the entity, expect load followed by immediate unload
+DespawnEntity entity="test_entity_a"
+RunUpdateOnce
+AssertCallbackSuccess attachment="EntityScript", entity="test_entity_a", label="OnScriptLoaded", script="script_a", expect_string_value="loaded!"
+AssertCallbackSuccess attachment="EntityScript", entity="test_entity_a", label="OnScriptUnloaded", script="script_a", expect_string_value="unloaded!"
+AssertNoCallbackResponsesEmitted
+
+AssertContextResidents attachment="EntityScript", script="script_a", entity="test_entity_a", residents_num=0

--- a/crates/bevy_mod_scripting_core/src/commands.rs
+++ b/crates/bevy_mod_scripting_core/src/commands.rs
@@ -1,15 +1,12 @@
 //! Commands for creating, updating and deleting scripts
 
-use std::{sync::Arc, time::Duration};
+use std::{marker::PhantomData, sync::Arc, time::Duration};
 
 use crate::{
     IntoScriptPluginParams, ScriptContexts,
     callbacks::ScriptCallbacks,
     error::ScriptError,
-    event::{
-        CallbackLabel, ForPlugin, ScriptAttachedEvent, ScriptCallbackResponseEvent,
-        ScriptDetachedEvent,
-    },
+    event::{CallbackLabel, ScriptAttachedEvent, ScriptCallbackResponseEvent, ScriptDetachedEvent},
     handler::{ScriptingHandler, send_callback_response, send_script_errors},
     pipeline::RunProcessingPipelineOnce,
     script::Context,
@@ -230,23 +227,23 @@ impl<P: IntoScriptPluginParams> Command for RunScriptCallback<P> {
 
 /// Command which emits a [`ScriptAttachedEvent`] and then runs the processing pipeline to immediately process it.
 /// The end result is equivalent to attaching a script component or adding a static script and waiting for the normal pipeline to process it.
-pub struct AttachScript<P: IntoScriptPluginParams>(pub ForPlugin<ScriptAttachedEvent, P>);
+pub struct AttachScript<P: IntoScriptPluginParams>(ScriptAttachedEvent, PhantomData<fn(P)>);
 
 impl<P: IntoScriptPluginParams> AttachScript<P> {
     /// Creates a new [`AttachScript`] command, which will create the given attachment, run expected callbacks, and
     pub fn new(attachment: ScriptAttachment) -> Self {
-        Self(ForPlugin::new(ScriptAttachedEvent(attachment)))
+        Self(ScriptAttachedEvent(attachment), Default::default())
     }
 }
 
 /// Command which emits a [`ScriptDetachedEvent`] and then runs the processing pipeline to immediately process it.
 /// The end result is equivalent to detaching a script component or removing a static script and waiting for the normal pipeline to process it.
-pub struct DetachScript<P: IntoScriptPluginParams>(pub ForPlugin<ScriptDetachedEvent, P>);
+pub struct DetachScript<P: IntoScriptPluginParams>(ScriptDetachedEvent, PhantomData<fn(P)>);
 
 impl<P: IntoScriptPluginParams> DetachScript<P> {
     /// Creates a new [`DetachScript`] command, which will create the given attachment, run all expected callbacks, and delete contexts if necessary.
     pub fn new(attachment: ScriptAttachment) -> Self {
-        Self(ForPlugin::new(ScriptDetachedEvent(attachment)))
+        Self(ScriptDetachedEvent(attachment), Default::default())
     }
 }
 

--- a/crates/bevy_mod_scripting_core/src/pipeline/machines.rs
+++ b/crates/bevy_mod_scripting_core/src/pipeline/machines.rs
@@ -5,7 +5,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use bevy_ecs::event::Event;
+use bevy_ecs::{event::Event, world::Mut};
 use bevy_log::trace;
 use bevy_mod_scripting_bindings::{
     CurrentScriptAttachment, InteropError, ScriptValue, WorldExtensions,
@@ -32,11 +32,8 @@ pub struct ActiveMachinesData(pub HashMap<ScriptAttachment, MachineData>);
 #[derive(Resource)]
 pub struct ActiveMachines<P: IntoScriptPluginParams> {
     active_machine: Option<ScriptMachine<P>>,
-    initialized_machines: VecDeque<Box<dyn MachineState<P>>>,
-    uninitialized_machines: VecDeque<(
-        MachineContext,
-        Box<dyn FnOnce(&mut World) -> Vec<Box<dyn MachineState<P>>> + Send + Sync + 'static>,
-    )>,
+    initialized_machines: VecDeque<(MachineContext, Box<dyn MachineState<P>>)>,
+    uninitialized_machines: VecDeque<ScriptPipelineEvent>,
     /// The current time budget per frame
     pub budget: Option<Duration>,
 }
@@ -49,43 +46,6 @@ impl<P: IntoScriptPluginParams> Default for ActiveMachines<P> {
             uninitialized_machines: Default::default(),
             budget: Default::default(),
         }
-    }
-}
-
-/// Trait describing subscribers to transition events
-pub trait TransitionListener<State>: 'static + Send + Sync {
-    /// The hook to call when entering the state being listened to
-    fn on_enter(
-        &self,
-        state: &mut State,
-        world: &mut World,
-        context: &mut MachineContext,
-    ) -> Result<(), ScriptError>;
-
-    /// type erase the listener
-    fn erased<P: IntoScriptPluginParams>(
-        self,
-    ) -> Box<
-        dyn Fn(&mut dyn MachineState<P>, &mut World, &mut MachineContext) -> Result<(), ScriptError>
-            + Send
-            + Sync,
-    >
-    where
-        Self: Sized,
-        State: 'static,
-    {
-        Box::new(move |state, world, context| {
-            let typed = (state as &mut dyn Any).downcast_mut::<State>();
-            typed
-                .ok_or(ScriptError::new_boxed_without_type_info(
-                    format!(
-                        "could not downcast script machine state to: '{}'. Could not execute transition listener",
-                        std::any::type_name::<State>()
-                    )
-                    .into(),
-                ))
-                .and_then(|typed| self.on_enter(typed, world, context))
-        })
     }
 }
 
@@ -138,33 +98,43 @@ impl<P: IntoScriptPluginParams> ActiveMachines<P> {
                 }
             } else {
                 // initialize a machine and re-check
-                if let Some((context, initializer)) = self.uninitialized_machines.pop_front() {
-                    let machines = initializer(world);
-                    self.initialized_machines.extend(machines);
-                    if let Some(machine) = self.initialized_machines.pop_front() {
-                        trace!(
-                            "State machine '{}' queued. For script: {}",
-                            machine.state_name(),
-                            context.attachment,
-                        );
-                        self.active_machine = Some(ScriptMachine {
-                            context,
-                            internal_state: MachineExecutionState::Initialized(machine),
-                        });
-                    }
+                if let Some(event) = self.uninitialized_machines.pop_front() {
+                    world.resource_scope(|world, mut assets: Mut<Assets<ScriptAsset>>| {
+                        world.resource_scope(|_world, mut contexts: Mut<ScriptContexts<P>>| {
+                            self.initialized_machines.extend(
+                                event.process(&mut assets, &mut contexts).into_iter().map(
+                                    |(attachment, machine)| {
+                                        (MachineContext { attachment }, machine)
+                                    },
+                                ),
+                            );
+                            if let Some((context, machine)) = self.initialized_machines.pop_front()
+                            {
+                                trace!(
+                                    "State machine '{}' queued. For script: {}",
+                                    machine.state_name(),
+                                    context.attachment,
+                                );
+                                self.active_machine = Some(ScriptMachine {
+                                    context,
+                                    internal_state: MachineExecutionState::Initialized(machine),
+                                });
+                            }
+                        })
+                    })
                 }
             }
         }
     }
 
     /// Appends a machine to the end of the queue.
-    pub fn queue_machine(
-        &mut self,
-        context: MachineContext,
-        init: impl FnOnce(&mut World) -> Vec<Box<dyn MachineState<P>>> + Send + Sync + 'static,
-    ) {
-        self.uninitialized_machines
-            .push_back((context, Box::new(init)));
+    pub fn queue_machine(&mut self, event: ScriptPipelineEvent) {
+        self.uninitialized_machines.push_back(event);
+    }
+
+    /// Appends a machine to the end of the queue.
+    pub fn queue_machines(&mut self, events: impl IntoIterator<Item = ScriptPipelineEvent>) {
+        self.uninitialized_machines.extend(events);
     }
 
     /// Returns the amount of queued machines minus any currently processing ones

--- a/crates/bevy_mod_scripting_core/src/pipeline/mod.rs
+++ b/crates/bevy_mod_scripting_core/src/pipeline/mod.rs
@@ -15,7 +15,6 @@ use bevy_ecs::{
 use bevy_log::debug;
 use bevy_mod_scripting_asset::{Language, ScriptAsset};
 use bevy_mod_scripting_display::DisplayProxy;
-use bevy_platform::collections::HashSet;
 use parking_lot::Mutex;
 
 use crate::{
@@ -157,7 +156,8 @@ pub trait GetScriptHandle {
 ///
 /// Think of this as a proxy for "baby'ing" asset handles
 pub struct LoadedWithHandles<'w, 's, T: GetScriptHandle + Message + Clone> {
-    assets: ResMut<'w, Assets<ScriptAsset>>,
+    /// The script assets resource. To allow systems needing both resources to access them in one place
+    pub assets: ResMut<'w, Assets<ScriptAsset>>,
     asset_server: Res<'w, AssetServer>,
     fresh_events: MessageReader<'w, 's, T>,
     loaded_with_handles: Local<'s, VecDeque<(T, StrongScriptHandle, Language)>>,
@@ -252,40 +252,15 @@ impl<P: IntoScriptPluginParams> Plugin for ScriptLoadingPipeline<P> {
                 .before(PipelineSet::MachineStartPhase),
         );
 
-        // todo: nicer way to order these, ideall .chain() + conditional newtype?
-        if self.script_component_triggers {
-            app.add_systems(
-                PreUpdate,
-                filter_script_attachments::<P>
-                    .in_set(PipelineSet::ListeningPhase)
-                    .before(filter_script_modifications::<P>)
-                    .before(filter_script_detachments::<P>),
-            );
-            app.add_systems(
-                PreUpdate,
-                filter_script_detachments::<P>
-                    .in_set(PipelineSet::ListeningPhase)
-                    .after(filter_script_attachments::<P>)
-                    .before(filter_script_modifications::<P>),
-            );
-        }
-
-        if self.hot_loading_asset_triggers {
-            app.add_systems(
-                PreUpdate,
-                filter_script_modifications::<P>.in_set(PipelineSet::ListeningPhase),
-            );
-        }
-
+        let sync_components = self.script_component_triggers;
+        let hot_loads = self.hot_loading_asset_triggers;
+        let input_system = move || FilterAssetEventsSettings {
+            sync_components,
+            hot_loads,
+        };
         app.add_systems(
             PreUpdate,
-            (
-                process_attachments::<P>,
-                process_detachments::<P>,
-                process_asset_modifications::<P>,
-            )
-                .chain()
-                .in_set(PipelineSet::MachineStartPhase),
+            (input_system.pipe(filter_asset_events::<P>)).in_set(PipelineSet::ListeningPhase),
         );
 
         app.add_systems(

--- a/crates/bevy_mod_scripting_core/src/pipeline/start.rs
+++ b/crates/bevy_mod_scripting_core/src/pipeline/start.rs
@@ -2,8 +2,9 @@ use crate::script::Context;
 
 use super::*;
 use bevy_asset::AssetEvent;
-use bevy_ecs::message::{MessageReader, MessageWriter};
+use bevy_ecs::{message::MessageReader, system::In};
 use bevy_log::{debug, trace};
+use bevy_mod_scripting_script::ScriptAttachment;
 
 /// A handle to a script asset which can only be made from a strong handle
 #[derive(Clone, Debug)]
@@ -59,220 +60,220 @@ impl StrongScriptHandle {
     }
 }
 
-/// Generate [`ScriptAssetModifiedEvent`]'s from asset modification events, filtering to only forward those matching the plugin's language
-pub fn filter_script_modifications<P: IntoScriptPluginParams>(
-    mut events: MessageReader<AssetEvent<ScriptAsset>>,
-    mut filtered: MessageWriter<ForPlugin<ScriptAssetModifiedEvent, P>>,
-    assets: Res<Assets<ScriptAsset>>,
-) {
-    let mut batch = events.read().filter_map(|e| {
-        if let AssetEvent::Modified { id } = e
-            && let Some(asset) = assets.get(*id)
-            && asset.language == P::LANGUAGE
-        {
-            Some(ForPlugin::new(ScriptAssetModifiedEvent(*id)))
-        } else {
-            None
-        }
-    });
-
-    if let Some(next) = batch.next() {
-        filtered.write_batch(std::iter::once(next).chain(batch));
-    }
+/// Arguments used to filter out certain sync events
+pub struct FilterAssetEventsSettings {
+    /// Whether or not to trigger component sync events
+    pub sync_components: bool,
+    /// Whether or not to trigger hot load sync events
+    pub hot_loads: bool,
 }
 
-/// Filters incoming [`ScriptAttachedEvent`]'s leaving only those which match the plugin's language
-pub fn filter_script_attachments<P: IntoScriptPluginParams>(
-    mut events: LoadedWithHandles<ScriptAttachedEvent>,
-    mut filtered: MessageWriter<ForPlugin<ScriptAttachedEvent, P>>,
+/// A system that bridges various script events and the script processing pipeline.
+pub fn filter_asset_events<P: IntoScriptPluginParams>(
+    args: In<FilterAssetEventsSettings>,
+    mut script_modified_events: MessageReader<AssetEvent<ScriptAsset>>,
+    mut script_attached_events: LoadedWithHandles<ScriptAttachedEvent>,
+    mut script_detached_events: MessageReader<ScriptDetachedEvent>,
+    mut active_machines: ResMut<ActiveMachines<P>>,
 ) {
-    let mut batch = events
-        .get_loaded()
-        .filter(|(_, _, l)| *l == P::LANGUAGE)
-        .map(|(mut a, b, _)| {
-            trace!(
-                "dispatching script attachment event for: {a:?}, language: {}",
-                P::LANGUAGE
-            );
-            *a.0.script_mut() = b.0;
-            ForPlugin::new(a)
+    if args.hot_loads {
+        let batch = script_modified_events.read().filter_map(|e| {
+            if let AssetEvent::Modified { id } = e
+                && let Some(asset) = script_attached_events.assets.get(*id)
+                && asset.language == P::LANGUAGE
+            {
+                Some(ScriptPipelineEvent::ModifiedAsset(
+                    ScriptAssetModifiedEvent(*id),
+                ))
+            } else {
+                None
+            }
         });
+        active_machines.queue_machines(batch);
+    }
 
-    if let Some(next) = batch.next() {
-        filtered.write_batch(std::iter::once(next).chain(batch));
+    if args.sync_components {
+        let batch = script_attached_events
+            .get_loaded()
+            .filter(|(_, _, l)| *l == P::LANGUAGE)
+            .map(|(mut a, b, _)| {
+                trace!(
+                    "dispatching script attachment event for: {a:?}, language: {}",
+                    P::LANGUAGE
+                );
+                *a.0.script_mut() = b.0;
+                ScriptPipelineEvent::Attached(a)
+            });
+
+        active_machines.queue_machines(batch);
+
+        // we can't actually filter those based on their existence in the script contexts, as processing an attachment might
+        // create the script, so we want to do that in order
+        let batch = script_detached_events
+            .read()
+            .cloned()
+            .map(ScriptPipelineEvent::Detached);
+
+        active_machines.queue_machines(batch);
     }
 }
 
-/// Filters incoming [`ScriptDetachedEvent`]'s leaving only those which are currently attached and match the plugin's language
-pub fn filter_script_detachments<P: IntoScriptPluginParams>(
-    mut events: MessageReader<ScriptDetachedEvent>,
-    mut filtered: MessageWriter<ForPlugin<ScriptDetachedEvent, P>>,
-    contexts: Res<ScriptContexts<P>>,
-) {
-    let contexts_guard = contexts.read();
-    let mut batch = events
-        .read()
-        .filter(|e| contexts_guard.contains(&e.0))
-        .cloned()
-        .map(ForPlugin::new);
-
-    if let Some(next) = batch.next() {
-        trace!("dispatching script dettachments for plugin");
-        filtered.write_batch(std::iter::once(next).chain(batch));
-    }
+/// A discriminated union of all events that can trigger the script processing pipeline.
+pub enum ScriptPipelineEvent {
+    /// [`ScriptAttachedEvent`]
+    Attached(ScriptAttachedEvent),
+    /// [`ScriptDetachedEvent`]
+    Detached(ScriptDetachedEvent),
+    /// [`ScriptAssetModifiedEvent`]
+    ModifiedAsset(ScriptAssetModifiedEvent),
 }
 
-/// Process [`ScriptAttachedEvent`]'s and generate loading machines with the [`LoadingInitialized`] and [`ReloadingInitialized`] states
-pub fn process_attachments<P: IntoScriptPluginParams>(
-    mut events: MessageReader<ForPlugin<ScriptAttachedEvent, P>>,
-    mut machines: ResMut<ActiveMachines<P>>,
-    mut assets: ResMut<Assets<ScriptAsset>>,
-) {
-    // let contexts = contexts.read();
-    events.read().for_each(|wrapper| {
-        let attachment_event = wrapper.event();
+impl ScriptPipelineEvent {
+    fn process_attachment<P: IntoScriptPluginParams>(
+        attachment_event: ScriptAttachedEvent,
+        assets: &mut Assets<ScriptAsset>,
+        contexts: &mut ScriptContexts<P>,
+    ) -> VecDeque<(ScriptAttachment, Box<dyn MachineState<P>>)> {
+        let mut out = VecDeque::default();
         let attachment = attachment_event.0.clone();
         debug!("received attachment event: {attachment_event:?}");
         let id = attachment_event.0.script();
         let mut context = MachineContext {
             attachment: attachment.clone(),
         };
-        if let Some(strong_handle) = StrongScriptHandle::from_assets(id, &mut assets) {
+        if let Some(strong_handle) = StrongScriptHandle::from_assets(id, assets) {
             // we want the loading process to have access to asset paths
             *context.attachment.script_mut() = strong_handle.0.clone();
-            let content = strong_handle.get(&assets);
+            let content = strong_handle.get(assets);
 
             // we query for the contexts to decide if this is a reload or load at runtime
             // not when queueing, in case another machine before this one affects the state, we do need the asset though
-            machines.queue_machine(context, move |w| {
-                let contexts = w.get_resource_or_init::<ScriptContexts<P>>();
-                let mut contexts = contexts.write();
 
-                match contexts.get_context(&attachment) {
-                    Some(Context::LoadedAndActive(context)) => {
-                        if let Err((attachment, _)) =
-                            contexts.insert(attachment.clone(), Context::Reloading(context.clone()))
-                        {
-                            bevy_log::warn!("Could not insert context for attachment {attachment}. Reloading interrupted.");
-                        };
+            let mut contexts = contexts.write();
 
-                        vec![Box::new(ReloadingInitialized {
+            out.extend(match contexts.get_context(&attachment) {
+                Some(Context::LoadedAndActive(context)) => {
+                    if let Err((attachment, _)) =
+                        contexts.insert(attachment.clone(), Context::Reloading(context.clone()))
+                    {
+                        bevy_log::warn!(
+                            "Could not insert context for attachment {attachment}. Reloading interrupted."
+                        );
+                    };
+
+                    vec![(
+                        attachment.clone(), 
+                        Box::new(ReloadingInitialized {
                             attachment: attachment.clone(),
                             source: strong_handle.handle().clone(),
                             content: content.content,
                             existing_context: context,
-                        })]
-                    }
-                    // context is in an invalid state
-                    Some(_) => vec![],
-                    None => {
-                        if let Err((attachment, _)) =
-                            contexts.insert(attachment.clone(), Context::Loading)
-                        {
-                            bevy_log::warn!("Could not insert context for attachment {attachment}. Loading interrupted.");
-                        };
+                        })
+                     as Box<dyn MachineState<P>>)]
+                }
+                // context is in an invalid state
+                Some(_) => vec![],
+                None => {
+                    if let Err((attachment, _)) =
+                        contexts.insert(attachment.clone(), Context::Loading)
+                    {
+                        bevy_log::warn!(
+                            "Could not insert context for attachment {attachment}. Loading interrupted."
+                        );
+                    };
 
-                        vec![Box::new(LoadingInitialized {
-                            attachment: attachment.clone(),
-                            source: strong_handle.handle().clone(),
-                            content: content.content,
-                        })]
-                    }
+                    vec![(attachment.clone(), 
+                    Box::new(LoadingInitialized {
+                        attachment: attachment.clone(),
+                        source: strong_handle.handle().clone(),
+                        content: content.content,
+                    })as Box<dyn MachineState<P>>)]
                 }
             });
         }
-    });
-}
+        out
+    }
 
-/// Processes [`ScriptAttachedEvent`]'s and initialized unloading state machines with [`UnloadingInitialized`] states
-pub fn process_detachments<P: IntoScriptPluginParams>(
-    mut events: MessageReader<ForPlugin<ScriptDetachedEvent, P>>,
-    mut machines: ResMut<ActiveMachines<P>>,
-    contexts: Res<ScriptContexts<P>>,
-) {
-    events.read().for_each(|wrapper| {
-        let attachment_event = wrapper.event();
+    fn process_detachment<P: IntoScriptPluginParams>(
+        attachment_event: ScriptDetachedEvent,
+        contexts: &ScriptContexts<P>,
+    ) -> VecDeque<(ScriptAttachment, Box<dyn MachineState<P>>)> {
+        debug!("received detachment event: {attachment_event:?}");
         let attachment = &attachment_event.0;
-        let contexts_guard = contexts.read();
-        contexts_guard
+        let mut contexts = contexts.write();
+        contexts
             .get_context(&attachment_event.0)
             .into_iter()
-            .for_each(|existing_context| {
+            .filter_map(|existing_context| {
                 // for the borrow checker
                 let attachment = attachment.clone();
-                machines.queue_machine(
-                    MachineContext {
-                        attachment: attachment.clone(),
-                    },
-                    move |world| {
-                        let contexts = world.get_resource_or_init::<ScriptContexts<P>>();
-                        let mut contexts = contexts.write();
 
-                        let existing_context = if let Some(context) = existing_context.as_loaded() {
-                            context
-                        } else {
-                            // cannot unload a context which isn't loaded
-                            return vec![];
-                        };
+                let existing_context = existing_context.as_loaded()?;
 
-                        if let Err((attachment, _)) =
-                            contexts.insert(attachment.clone(), Context::Unloading(existing_context.clone()))
-                        {
-                            bevy_log::warn!("Could not insert context for attachment {attachment}. Unloading interrupted.");
-                        };
+                if let Err((attachment, _)) =
+                    contexts.insert(attachment.clone(), Context::Unloading(existing_context.clone()))
+                {
+                    bevy_log::warn!("Could not insert context for attachment {attachment}. Unloading interrupted.");
+                };
 
-                        vec![Box::new(UnloadingInitialized {
-                                    attachment,
-                                    existing_context: existing_context.clone(),
-                                }) as Box<dyn MachineState<P>>
-                            ]
-                    },
-                );
-            })
-    });
-}
+                Some((attachment.clone(), Box::new(UnloadingInitialized {
+                            attachment,
+                            existing_context: existing_context.clone(),
+                        }) as Box<dyn MachineState<P>>))
+            }).collect()
+    }
 
-/// Processes [`ScriptAssetModifiedEvent`]'s and initializes loading state machines with [`ReloadingInitialized`] states
-pub fn process_asset_modifications<P: IntoScriptPluginParams>(
-    mut events: MessageReader<ForPlugin<ScriptAssetModifiedEvent, P>>,
-    mut machines: ResMut<ActiveMachines<P>>,
-    mut assets: ResMut<Assets<ScriptAsset>>,
-    contexts: Res<ScriptContexts<P>>,
-) {
-    let affected_ids = events.read().map(|e| e.event().0).collect::<HashSet<_>>();
+    fn process_modified_asset<P: IntoScriptPluginParams>(
+        event: ScriptAssetModifiedEvent,
+        assets: &mut Assets<ScriptAsset>,
+        contexts: &ScriptContexts<P>,
+    ) -> VecDeque<(ScriptAttachment, Box<dyn MachineState<P>>)> {
+        let contexts = contexts.read();
+        debug!("received modified event: {event:?}");
 
-    let contexts = contexts.read();
+        let affected_attachments = contexts
+            .all_residents()
+            .filter(|(a, _)| event.0 == a.script().id());
 
-    let affected_attachments = contexts
-        .all_residents()
-        .filter(|(a, _)| affected_ids.contains(&a.script().id()));
-
-    affected_attachments
-        .into_iter()
-        .for_each(|(attachment, existing_context)| {
+        let mut out = VecDeque::default();
+        for (attachment, existing_context) in affected_attachments {
             let id = attachment.script();
-            if let Some(strong_handle) = StrongScriptHandle::from_assets(id, &mut assets) {
-                let content = strong_handle.get(&assets);
-
-                machines.queue_machine(
-                    MachineContext {
-                        attachment: attachment.clone(),
-                    },
-                    move |_| {
-                        existing_context
-                            .as_loaded()
-                            .map(|existing_context| {
-                                Box::new(ReloadingInitialized {
-                                    attachment,
-                                    source: strong_handle.handle().clone(),
-                                    content: content.content,
-                                    existing_context: existing_context.clone(),
-                                }) as Box<dyn MachineState<P>>
-                            })
-                            .into_iter()
-                            .collect::<Vec<_>>()
-                    },
-                );
+            if let Some(strong_handle) = StrongScriptHandle::from_assets(id, assets) {
+                let content = strong_handle.get(assets);
+                if let Some(existing_context) = existing_context.as_loaded() {
+                    out.push_back((
+                        attachment.clone(),
+                        Box::new(ReloadingInitialized {
+                            attachment: attachment.clone(),
+                            source: strong_handle.handle().clone(),
+                            content: content.content,
+                            existing_context: existing_context.clone(),
+                        }) as Box<dyn MachineState<P>>,
+                    ));
+                }
             }
-        });
+        }
+        out
+    }
+
+    /// Initializes a machine that can be run by the script processing pipeline.
+    /// This is the moment we "commit" to the checks required by each machine.
+    /// For example detachments check if the attachment exists and don't do anything otherwise.
+    pub fn process<P: IntoScriptPluginParams>(
+        self,
+        assets: &mut Assets<ScriptAsset>,
+        contexts: &mut ScriptContexts<P>,
+    ) -> VecDeque<(ScriptAttachment, Box<dyn MachineState<P>>)> {
+        match self {
+            ScriptPipelineEvent::Attached(script_attached_event) => {
+                Self::process_attachment(script_attached_event, assets, contexts)
+            }
+            ScriptPipelineEvent::Detached(script_detached_event) => {
+                Self::process_detachment(script_detached_event, contexts)
+            }
+            ScriptPipelineEvent::ModifiedAsset(script_asset_modified_event) => {
+                Self::process_modified_asset(script_asset_modified_event, assets, contexts)
+            }
+        }
+    }
 }

--- a/crates/bevy_mod_scripting_core/src/pipeline/start.rs
+++ b/crates/bevy_mod_scripting_core/src/pipeline/start.rs
@@ -162,7 +162,7 @@ impl ScriptPipelineEvent {
                     };
 
                     vec![(
-                        attachment.clone(), 
+                        attachment.clone(),
                         Box::new(ReloadingInitialized {
                             attachment: attachment.clone(),
                             source: strong_handle.handle().clone(),
@@ -182,7 +182,7 @@ impl ScriptPipelineEvent {
                         );
                     };
 
-                    vec![(attachment.clone(), 
+                    vec![(attachment.clone(),
                     Box::new(LoadingInitialized {
                         attachment: attachment.clone(),
                         source: strong_handle.handle().clone(),

--- a/crates/bevy_mod_scripting_world/src/access_map.rs
+++ b/crates/bevy_mod_scripting_world/src/access_map.rs
@@ -316,7 +316,7 @@ impl AccessMapInner {
                     || self
                         .component_access
                         .iter_accessed()
-                        .any(|(_, a)| a.is_write() || (!a.is_write() && write))
+                        .any(|(_, a)| a.is_write() || write)
                 {
                     return false;
                 }


### PR DESCRIPTION
# Summary
This used to work in previous versions, but stopped when the new pipeline work got merged. Also simplifies things a bit.

This PR delays the "commitment" step of script machines further into the process. allowing both an attachment and detachment to happen in the same frame and be processed one after another.

This may be slightly jarring from a script perspective, as the entity you're attached to might be despawned by the time you execute, but that's unavoidable in this execution model.

Fixes #468