### PR TITLE
fix: breaking compilation, when `bevy_reflect`, `functions` feature is enabled

### DIFF
--- a/crates/bevy_mod_scripting_display/src/printer/mod.rs
+++ b/crates/bevy_mod_scripting_display/src/printer/mod.rs
@@ -167,6 +167,12 @@ impl<'f, 'b: 'f, 't> ReflectPrinter<'f, 'b, 't> {
                 }
             }
             ReflectRef::Opaque(o) => o.debug(self.formatter),
+            // here to support feature gated ReflectRef::Function variant
+            #[allow(
+                unreachable_patterns,
+                reason = "feature gated variant breaks things depending on features"
+            )]
+            _ => self.formatter.write_str("Unsupported reflect value"),
         }
     }
 


### PR DESCRIPTION
# Summary
Because the `ReflectRef` enum is not marked as non-exhausitve, and one of its variants is feature gated, it is introduces a non-obvious compilation breakage