### PR TITLE
fix: LLS generation for `self` parameters

### DIFF
--- a/crates/lad_backends/lua_language_server_lad_backend/src/plugin.rs
+++ b/crates/lad_backends/lua_language_server_lad_backend/src/plugin.rs
@@ -17,7 +17,7 @@ pub struct LuaLanguageServerLadPlugin {
 impl Default for LuaLanguageServerLadPlugin {
     fn default() -> Self {
         Self {
-            filename: PathBuf::from("bindings.lua"),
+            filename: PathBuf::from("bindings.d.lua"),
         }
     }
 }

--- a/crates/lad_backends/lua_language_server_lad_backend/templates/declaration_file.tera
+++ b/crates/lad_backends/lua_language_server_lad_backend/templates/declaration_file.tera
@@ -43,7 +43,7 @@
 {%- endfor -%}
 {%- for return in function.returns -%}
 ---@return {{ self::lua_type(ty=return, return_position=true) }}
-function {% if module.class -%}{%- if function.has_self -%}{{module.class.name}}:{%- else -%}{{module.class.name}}.{%- endif -%}{%- endif -%} {{ function.name }}(
+function {% if module.class -%}{{module.class.name}}.{%- endif -%} {{ function.name }}(
     {%- for param in function.params -%}
         {% if param.variadic -%}... {% endif-%}{{ param.name }} {%- if not loop.last -%},{%- endif -%}
     {%- endfor -%}

--- a/crates/lad_backends/lua_language_server_lad_backend/tests/.gitignore
+++ b/crates/lad_backends/lua_language_server_lad_backend/tests/.gitignore
@@ -1,2 +1,2 @@
 example_ladfile/test.lad.json
-**/bindings.lua
+**/bindings.d.lua

--- a/crates/lad_backends/lua_language_server_lad_backend/tests/example_ladfile/expected.lua
+++ b/crates/lad_backends/lua_language_server_lad_backend/tests/example_ladfile/expected.lua
@@ -10,7 +10,7 @@ PlainStructType = {}
 ---@param p1 PlainStructType 
 ---@param p2 integer 
 ---@return any
-function PlainStructType:plain_struct_function(p1,p2) end
+function PlainStructType.plain_struct_function(p1,p2) end
 
 
 


### PR DESCRIPTION
# Summary
These were not generating correctly. It seems lua language server doesn't respect `:`. best to just use `.` dispatch and be explicit with params